### PR TITLE
test(maid-atelier): 防止私有 preset 门控回归

### DIFF
--- a/maid-atelier/tests/apply.spec.ts
+++ b/maid-atelier/tests/apply.spec.ts
@@ -12,6 +12,9 @@ import { resolve } from 'node:path'
 import { apply } from '../src/client/index.ts'
 
 const CSS = readFileSync(resolve(process.cwd(), 'src/client/maid-atelier.module.css'), 'utf8')
+const CLIENT_SOURCE = readFileSync(resolve(process.cwd(), 'src/client/index.ts'), 'utf8')
+const CLIENT_BUNDLE = readFileSync(resolve(process.cwd(), 'lib/client.js'), 'utf8')
+const PRIVATE_PRESET = ['whale', 'minimal'].join('-')
 
 /**
  * Declarations of the settings-open rule governing the sidebar content root's
@@ -60,6 +63,17 @@ describe('Maid Atelier skin apply', () => {
     expect(document.body.hasAttribute('data-dsh-maid-atelier')).toBe(true)
     await fiber.dispose()
     expect(document.body.hasAttribute('data-dsh-maid-atelier')).toBe(false)
+  })
+
+  it('activates unconditionally and carries no private preset gate', async () => {
+    document.body.dataset.agentPreset = 'standard'
+
+    expect(CLIENT_SOURCE).not.toContain(PRIVATE_PRESET)
+    expect(CLIENT_BUNDLE).not.toContain(PRIVATE_PRESET)
+
+    fiber = await mount()
+    expect(document.body.hasAttribute('data-dsh-maid-atelier')).toBe(true)
+    expect(document.querySelector('[data-skin-chrome]')).not.toBeNull()
   })
 
   it('registers cleanup before a later CSSOM initialization failure', () => {

--- a/maid-atelier/tests/apply.spec.ts
+++ b/maid-atelier/tests/apply.spec.ts
@@ -65,15 +65,11 @@ describe('Maid Atelier skin apply', () => {
     expect(document.body.hasAttribute('data-dsh-maid-atelier')).toBe(false)
   })
 
-  it('activates unconditionally and carries no private preset gate', async () => {
-    document.body.dataset.agentPreset = 'standard'
-
+  it('does not reintroduce a private preset gate', () => {
+    // This skin has no sessions service fixture or dependency contract here;
+    // keep this regression guard focused on the forbidden hard-coded gate.
     expect(CLIENT_SOURCE).not.toContain(PRIVATE_PRESET)
     expect(CLIENT_BUNDLE).not.toContain(PRIVATE_PRESET)
-
-    fiber = await mount()
-    expect(document.body.hasAttribute('data-dsh-maid-atelier')).toBe(true)
-    expect(document.querySelector('[data-skin-chrome]')).not.toBeNull()
   })
 
   it('registers cleanup before a later CSSOM initialization failure', () => {


### PR DESCRIPTION
## 摘要

这是针对 PR #48 维护者反馈的仅测试后续。

- 新增回归断言，确保 `maid-atelier` 源码和 `lib/client.js` 不包含私有的 `whale-minimal` preset 门控。
- 删除测试中无效的 DOM `agentPreset` 标记。
- 不包含任何运行时代码修改。

## 背景

`whale-minimal` 是我本地 Harness 中的私人 preset，不应成为公共皮肤的激活条件。最新 `main` 已经不存在该门控，`apply()` 也保持无条件激活；本 PR 仅用于防止这一行为回归。

当前仓库的测试没有提供 `sessions` 服务快照 fixture 或依赖契约，因此回归测试不会臆造这类模拟数据，而是仅检查源码和已提交构建产物中不存在被禁止的硬编码 preset 门控。

## 验证

- `npx --yes pnpm@10 test`（90/90）
- `npx --yes pnpm@10 build`