### PR TITLE
chore(security): 安全卫生加固 — SECURITY.md / Dependabot / CI SHA 固定 / .env 防护

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot 版本更新配置：跟踪 GitHub Actions 与 npm 依赖
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(ci)"
+
+  - package-ecosystem: "npm"
+    directory: "/maid-atelier"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "npm"
+    directory: "/orca-link"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/pr-issue-check.yml
+++ b/.github/workflows/pr-issue-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 校验 PR 描述
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7 — 按提交哈希固定，防供应链投毒
         with:
           script: |
             const pr = context.payload.pull_request

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 *.tsbuildinfo
 *.js.map
 .DS_Store
+
+# 环境变量与本地密钥（兜底防护，防止误提交）
+.env
+.env.*
+!.env.example

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# 安全政策 · Security Policy
+
+## 支持范围 · Supported Versions
+
+本仓库分发预构建皮肤包（`maid-atelier/lib`、`orca-link/lib`）。安全修复只保证合入最新的 `main` 分支；请优先使用最新提交对应的构建产物。
+
+| 版本 | 支持状态 |
+|---|---|
+| `main` 分支最新提交 | ✅ 支持 |
+| 旧提交 / 历史版本 | ❌ 不再支持 |
+
+## 报告漏洞 · Reporting a Vulnerability
+
+皮肤是**纯展示层**（presentation-only）客户端插件：不注入服务、不发 Cordis 事件、不触达模型请求、不访问本地存储、素材全部内联（无远程资源依赖）。
+
+如发现安全问题，请**不要公开提交 issue**，按以下渠道私密上报：
+
+1. **首选**：GitHub 私有安全通告 —— 仓库页面 → Security → *Report a vulnerability*（或直接访问 <https://github.com/Small-tailqwq/dsh-deep-whale/security/advisories/new>），填写漏洞描述、影响范围与复现步骤。
+2. **备选**：在公开 issue 中**不要**贴出漏洞细节；可只发一条不含细节的占位说明（例如 "[安全] 发现隐私/供应链问题，已走私密上报"），待修复合入后再公开细节。
+
+## 响应预期 · What to Expect
+
+- 维护者会在 **7 个自然日内** 确认收到报告并评估影响。
+- 高危问题（隐私泄露、供应链投毒、任意代码执行）优先处理，修复合入后公开披露（标准 90 天披露窗口，可协商）。
+- 低危 / 中危问题（依赖漂移、CI 加固等）按正常维护节奏处理。
+
+## 已落地的加固 · Hardening in place
+
+- 素材全部以 base64 data URI 内联进 bundle，激活不依赖远程资源。
+- 构建期「纯度门禁」拒绝跨插件 value import（`build/tsdown.client.ts`）。
+- CI 工作流按提交 SHA 固定第三方 Action，并最小化 `permissions`。
+- 本仓库启用 Dependabot 跟踪依赖更新。


### PR DESCRIPTION
## 关联 Issue

无需 issue：纯安全加固，不改任何功能，也不碰皮肤代码。

## 改动内容

仓库级的安全卫生，一共四件事：

1. 新增 SECURITY.md —— 之前仓库没有任何漏洞上报渠道，补一个私密披露流程（走 GitHub Security Advisories）；
2. 新增 .github/dependabot.yml —— 开 Dependabot 跟踪 Actions 和 npm 依赖；
3. pr-issue-check.yml 里 actions/github-script@v7 固定到提交哈希 f28e40c7f34bde8b3046d885e986cb6290c5673b，防止标签被替换的供应链风险；
4. .gitignore 加上 .env* —— 防止本地密钥被误提交。

## 验证

- 纯配置和文档改动，不涉及运行行为，皮肤源码和 lib/ 产物都没动
- 固定用的 SHA 是从 v7 标签解析出来的，和标签指向一致
- CI 会在本 PR 触发时自己验证

## 兼容性自查

- 无 apply() / DOM / CSS 变更，不涉及主题、侧栏、布局、远程资源
- NOTICE / LICENSE 未动，无 lib/ 产物变更
