### PR TITLE
feat(skin-manager): finalize customization and agent hub integration

### DIFF
--- a/.agents/dsh-scaffold.json
+++ b/.agents/dsh-scaffold.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "scaffold": {
+    "repository": "https://github.com/Small-tailqwq/dsh-skin-template.git"
+  },
+  "consumers": [
+    {
+      "id": "maid-atelier",
+      "host": {
+        "repository": "https://github.com/deepseek-ai/deepseek-harness.git",
+        "version": "0.1.2-rc.1",
+        "ref": "refs/tags/dsh-v0.1.2-rc.1",
+        "sha": "a66e4702047846cdaa10c66c9d3df3951f5ea70d"
+      }
+    },
+    {
+      "id": "orca-link",
+      "host": {
+        "repository": "https://github.com/deepseek-ai/deepseek-harness.git",
+        "version": "0.1.2-rc.1",
+        "ref": "refs/tags/dsh-v0.1.2-rc.1",
+        "sha": "a66e4702047846cdaa10c66c9d3df3951f5ea70d"
+      }
+    }
+  ],
+  "shared": {
+    "notes": "link",
+    "knowledge": "link",
+    "skills": [
+      {
+        "name": "dsh-note-maintainer",
+        "mode": "link"
+      },
+      {
+        "name": "dsh-plugin-verify",
+        "mode": "link"
+      },
+      {
+        "name": "dsh-skin-upgrade",
+        "mode": "mirror"
+      }
+    ]
+  }
+}

--- a/.agents/skills/dsh-skin-upgrade/SKILL.md
+++ b/.agents/skills/dsh-skin-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-skin-upgrade
-description: "审计并适配 DSH Web 展示型皮肤或主题插件的宿主版本升级，覆盖官方源码契约、DOM/CSS 结构、客户端模块表、生命周期与提交型构建产物。普通服务或工具插件升级、皮肤安装切换、以及没有升级差异的单纯性能优化不使用本技能。"
+description: "审计并适配 DSH Web 展示型皮肤或主题插件的宿主版本升级，复用并补充按 exact SHA 持久化的宿主差异卡，再为当前皮肤独立建立影响矩阵；覆盖官方源码契约、DOM/CSS 结构、客户端模块表、生命周期与提交型构建产物。普通服务或工具插件升级、皮肤安装切换、以及没有升级差异的单纯性能优化不使用本技能。"
 ---
 
 # DSH Web 皮肤升级
@@ -18,17 +18,45 @@ description: "审计并适配 DSH Web 展示型皮肤或主题插件的宿主版
 2. 使用官方 `deepseek-ai/deepseek-harness` 仓库中的精确 tag 或 commit；记录解析后的完整 SHA。发布说明用于确定调查方向，源码和调用者决定兼容结论。
 3. 在独立 clone 或 detached worktree 中比较和适配。不要切换正在使用的源码 checkout，也不要把测试包 link 到用户当前 profile，除非用户明确要求运行验证。
 4. 记录皮肤基线 commit、目标 DSH commit、dirty state，以及本次是“只支持目标版本”还是“同时支持一段版本走廊”。后者必须来自用户要求或仓库支持契约，不能仅因手边有旧版源码就自行扩大。
-5. 历史适配提交只作行为与回归证据。用户要求独立适配或技能前向评测时，先在不读取目标版本答案卡、golden patch 或现成适配分支的条件下冻结审计矩阵与候选补丁，再做事后比较；评测 oracle 必须留在被测 agent 的输入之外。不要把终端或工具返回的 `git show`/`git diff` 文本当成完整文件来源：输出可能被 token/字符上限截断。读取当前文件后只应用必要 hunk；确需整文件替换时必须从未截断的文件对象读取并先核对行数与 hash。
+5. 历史适配提交只作行为与回归证据。普通工程升级允许按下文复用 Host Delta Card，但必须先从当前皮肤冻结 dependency contract keys；用户要求独立适配或技能前向评测时，在候选矩阵与补丁冻结前隐藏历史卡、golden patch 和现成适配分支，冻结后才作为 oracle 对照。不要把终端或工具返回的 `git show`/`git diff` 文本当成完整文件来源：输出可能被 token/字符上限截断。读取当前文件后只应用必要 hunk；确需整文件替换时必须从未截断的文件对象读取并先核对行数与 hash。
 6. 宿主源码 checkout 的 HEAD 只证明源树版本，不证明正在服务的运行产物版本。源码启动器可能直接加载被 Git 忽略的 workspace `lib`；依赖安装也不等于构建。真实宿主验证前按官方源码仓库的构建入口生成宿主产物，并用页面暴露的版本信息及至少一个目标版本独有的 DOM/行为锚点证明实际运行版本。同包名本地 link 改指另一个工作树时，profile 路径和启动清单包名也不能证明旧进程已换用候选 client artifact；还要核对 served revision/hash 或一个只存在于候选构建中的编译后行为。证据仍指向旧产物时停止视觉归因，按已授权的精确测试进程重启流程处理。
 7. 无法固定任一版本、运行产物或支持范围时只给风险判断，不宣称已适配。
 
-## 先生成本轮数据卡
+## 双层差异资产
 
-在修改皮肤前，按照 `contract-audit.md` 从本轮官方 base/target 源码与皮肤真实调用面现场生成升级数据卡并冻结初版。数据卡是技能本次运行的派生审计产物，不是技能随附知识：不得预填版本结论、复制历史数据卡，或先看目标版本的现成补丁再反推证据。
+升级记录分成两层，不能混写：
 
-数据卡至少记录精确版本坐标、宿主触点的基线/目标证据、皮肤调用点、变化层级、三态结论、拟采取动作与验证边界。默认放在任务临时目录或工作记录中，不进入皮肤发行包；只有用户明确要求留档时才提交到指定位置。实施中出现新证据可以追加或纠正卡片，但不能为了迎合已经写出的补丁而改写原始比较事实。
+1. **Host Delta Card**：脚手架 `.agents/knowledge/dsh-host-deltas/` 的持久化宿主事实，只写官方
+   repository、base/target 完整 SHA、Git object/blob、contract key 与
+   `changed / checked-unchanged / unknown`；不含任何皮肤补丁或视觉选择。
+2. **Skin Adoption Matrix**：当前皮肤本轮产生的影响卡，写皮肤 import/selector/owner、拟采取动作、
+   验证边界与 `受影响 / 无变化 / 未证实`。默认放当前任务忽略目录，不进入皮肤发行包。
 
-冻结门槛是“皮肤依赖清单中的每个候选触点都已有可复核证据并被归入三态之一”，不是“穷尽宿主全部 diff”。证据暂时闭合不了的行立即标为 `未证实`，记录缺口与后续验证方式；不要为了填满结论无限延长审计。冻结后保存数据卡 hash 或不可变快照，后续新发现另列增量记录，不能静默改写初版。
+B 皮肤可以服用 A 升级时证明的宿主事实，但不能继承 A 的“已适配”结论。卡片 identity 只认官方
+仓库与 exact SHA；tag/version 仅展示。已 verified 的 revision 不改写，补证或纠错新增 revision 并
+绑定上一文件 SHA-256；draft 只在首次晋升前补全。共享 store 不可写或脚手架工作树存在冲突时，把完整 card proposal 放当前皮肤
+`.agents/bridge-state/host-delta-drafts/`，最终明确报告 deferred；不要静默丢弃、自动 commit/push，
+也不要覆盖中央脏工作树。
+
+## 读取与冻结顺序
+
+1. 固定官方 base/target SHA、皮肤 commit/dirty state 与支持范围。
+2. **读取历史卡之前**，只从当前皮肤源码冻结 dependency contract keys；这是防止卡片把调查面
+   变成预写答案的边界。
+3. 读取 `.agents/knowledge/dsh-host-deltas/INDEX.md`，再用
+   `pnpm host-deltas:query -- --base <sha> --target <sha> --keys <key,key>` 只取相关事实。
+4. 对命中的每条 edge 记录 revision、file SHA-256 与 facts SHA-256；在可用官方对象库上运行
+   `pnpm host-deltas:verify-source -- --source <checkout> --base <sha> --target <sha>`。对象不符、
+   卡链断裂、反向、跨分支、缺 key 或 `unknown` 一律现场重查，不能猜成 unchanged。
+5. 把已验证宿主事实映射到当前皮肤，生成 Skin Adoption Matrix。冻结门槛是皮肤依赖清单中的
+   每个候选触点都有证据并进入三态之一，不要求穷尽宿主全部 diff；暂时闭合不了的立即标未证实。
+6. 保存 adoption 初版 hash 后才改代码。新证据写增量附录；不能迎合补丁静默改写初版。
+7. 卡里没有的通用宿主事实，从官方对象补证并形成下一 revision；皮肤特定实现只留 adoption/note。
+
+没有现成 edge 时，先用 `pnpm host-deltas:init -- --source <checkout> ...` 固定 diff inventory 和
+坐标，再填 facts、重新计算 `factsSha256`，用 `host-deltas:verify-source -- --include-draft` 核验后把
+status 从 draft 提升为 verified。schema、三态、revision 和查询规则见
+`.agents/knowledge/dsh-host-deltas/README.md`。
 
 ## 数据卡推导方法
 

--- a/.agents/skills/dsh-skin-upgrade/agents/openai.yaml
+++ b/.agents/skills/dsh-skin-upgrade/agents/openai.yaml
@@ -1,4 +1,7 @@
 interface:
   display_name: "DSH Skin Upgrade"
-  short_description: "审计、适配并验证 DSH Web 展示型皮肤的宿主版本升级"
-  default_prompt: "Use $dsh-skin-upgrade to audit and adapt this DSH Web skin for the target host release."
+  short_description: "复用宿主差异卡，审计并适配 DSH Web 皮肤升级"
+  default_prompt: "Use $dsh-skin-upgrade to reuse verified host delta facts and independently adapt this skin to the target DSH release."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/dsh-skin-upgrade/references/contract-audit.md
+++ b/.agents/skills/dsh-skin-upgrade/references/contract-audit.md
@@ -22,9 +22,16 @@
 
 命令输出不是文件对象。`git show`、`git diff` 和日志可能在代理工具的输出预算处被静默截断；不得把显示文本回填为整文件。历史实现用于确认意图和行为，当前基线文件才是编辑底稿。每批 patch 后用 diff stat、行数和必要时的 blob/hash 做规模哨兵，异常大幅删除立即停下处理。
 
-## 2. 生成本轮升级数据卡
+## 2. Host Delta Card 与 Skin Adoption Matrix
 
-数据卡必须由本轮 raw evidence 逐步生成，不能作为预写答案输入。开始编辑前完成并冻结初版，推荐结构：
+日常工程允许复用脚手架持久化的 Host Delta Card，但必须先从当前皮肤源码冻结 dependency
+contract keys。宿主卡只记录官方 DSH 的 exact-SHA 事实；当前皮肤的调用点、影响结论、动作与验证
+边界另写 Skin Adoption Matrix。不能把 A 皮肤的补丁或“已适配”结论当成 B 皮肤的证据。
+
+独立技能评测使用更严格的盲测顺序：候选矩阵和补丁冻结前不向被测 agent 提供宿主卡，冻结后才把
+卡当 oracle。日常工程和盲测都不能先看现成皮肤补丁再反推证据。
+
+Skin Adoption Matrix 推荐结构：
 
 ```markdown
 # DSH skin upgrade data card
@@ -43,14 +50,14 @@
 按以下顺序填充：
 
 1. 先解析版本坐标，记录官方 remote、完整 SHA 和 dirty state；统计大 diff 只用于规划，不能直接生成兼容结论。
-2. 从皮肤源码、manifest 与 build 入口生成依赖清单；每个 import、selector、owner 关系、生命周期资源和提交型产物都是候选行。
-3. 对每个候选行分别读取 base 与 target 的文件对象、定义和调用者，记录可复核的路径、symbol、blob/hash 或调用链证据，再判断名称、语义、关系、生命周期中的哪一层变化。
-4. 反向检查宿主 changed files：凡是进入皮肤已接管展示面的新增控件、状态或 portal，即使皮肤原先没有 selector，也新增一行。
-5. 只有 base/target 与皮肤调用面证据闭合时标记 `受影响` 或 `无变化`；证据缺口、必须实机观察或缺失 artifact 时标记 `未证实`。
-6. 当依赖清单中的候选触点已经全部进入三态即可冻结；不要求遍历或解释宿主仓库每一项无关 diff。无法在本轮冷审计闭合的事实保留为 `未证实`，不得以继续扩大搜索面来推迟冻结。
-7. 冻结初版数据卡后记录 hash 或不可变快照，才实施补丁。独立评测中，在候选补丁也冻结前不得读取现成适配分支或 golden patch；事后比较和新增证据单独记录，不回填或静默改写成“当时已知”的事实。
-
-数据卡默认是临时工作产物，不写入发行包或 skill reference。用户要求长期留档时，把它放到用户指定的审计/评测位置，并明确它是某次版本比较结果，不能成为后续版本自动加载的前置知识。
+2. 从皮肤源码、manifest 与 build 入口生成依赖 key；每个 import、selector、owner 关系、生命周期资源和提交型产物都是候选。
+3. 冻结 dependency keys 后，查询 exact edge 或连续卡链。逐 edge 校验 revision/file/facts hash，并用官方对象库核对 merge-base、name-status digest、blob 与 locator。tag 或版本相同不能替代对象验证。
+4. 卡链中相关 key 全部 `checked-unchanged` 才能复用无变化事实；任一 `changed` 要求当前皮肤复核；缺 key、`unknown`、断链、反向或跨分支均为未证实。中途 changed 不能自动推出最终仍 changed，因为后续可能回滚。
+5. 对没有卡覆盖的候选分别读取 base 与 target 文件对象、定义和调用者，记录路径、symbol、blob/hash 或调用链，再判断变化层级。
+6. 反向检查宿主 changed files：凡是进入皮肤已接管展示面的新增控件、状态或 portal，即使皮肤原先没有 selector，也新增一行。
+7. 只有宿主事实与当前皮肤调用面证据闭合时标记 `受影响` 或 `无变化`；证据缺口、必须实机观察或缺失 artifact 时标记 `未证实`。
+8. 依赖清单全部进入三态后冻结 adoption 初版并记录 hash，才实施补丁；新发现另列增量记录，不静默回填成“当时已知”。
+9. 新的通用宿主事实写入下一张不可变 card revision；皮肤决定不进入宿主卡。中央不可写时写本地 proposal，并明确 deferred，不自动提交或推送。
 
 ## 3. 收集皮肤依赖面
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository guidance
 
+<!-- dsh-agent-scaffold:v1 -->
+
 ## Code Review Rules
 
 ### Skin lifecycle
@@ -24,7 +26,8 @@
   - `skin.json`：皮肤清单（id/name/package/wiring/bodyAttr/preview/order）
   - `cordis.patch.yml`：bundle patch（`dsh.bundle.patch`，insert 皮肤行）
   - `NOTICE` / `LICENSE`：署名链与许可（CC BY-NC-SA 4.0）
-- `.agents/skills/`：`dsh-skin-install`（安装/切换/更新）、`dsh-plugin-verify`（三层验证）
+- `.agents/skills/`：仓库专属 `dsh-skin-install`；镜像的 `dsh-skin-upgrade`；本机桥接的
+  `dsh-note-maintainer` / `dsh-plugin-verify`。实际声明见 `.agents/dsh-scaffold.json`。
 - `AGENTS.md`：本文件
 
 ## Common issues & fixes（常见问题速查）
@@ -50,7 +53,7 @@
 
 ## Agent Notes
 
-- 皮肤开发/优化过程以 note 形式记录，规范与格式见脚手架仓库 `.agents/notes/README.md`（Problem/Decision/Alternatives considered/Consequences/Related 结构、闭集分类、生命周期）。
-- **权威副本与唯一维护地在脚手架仓库** `Small-tailqwq/dsh-skin-template`（`.agents/notes/implemented/<分类>/`），由 `dsh-note-maintainer` 技能在会话收尾时增/改；本仓库**不提交笔记**。
-- **共享方式**：本仓库 `.agents/notes/` 是指向脚手架 `.agents/notes/` 的目录 junction（Windows），已加入 `.gitignore`——clone 皮肤的用户不会拿到笔记，开发会话里两边经验实时互通（皮肤修复与皮肤创建的经验共通）。
-- 分类：compatibility（rc 适配）/ performance / stacking / install / process / skin。
+- 开始非平凡诊断前，先在 `.agents/notes/INDEX.md` 按症状/scope/contract key 渐进检索，只读命中的少量 note；宿主升级调用 `dsh-skin-upgrade`，先冻结当前皮肤依赖 key，再查 `.agents/knowledge/dsh-host-deltas/INDEX.md`。
+- **权威副本与唯一维护地在脚手架仓库** `Small-tailqwq/dsh-skin-template`；本仓库不提交共享 Note/Card。皮肤源码、`lib` 与 `skin.build.json` 作为本仓库发布提交，知识变更在脚手架另行提交，用 Related/commit SHA 互链。
+- 每次非平凡修复、结构/流程变化或宿主升级收尾，必须调用 `dsh-note-maintainer` 并明确输出 `Agent Notes: 增 / 改 / 不记 / deferred`。Junction 可读不等于中央可写；不可写或中央文件冲突时把完整草稿写入本地忽略的 `.agents/bridge-state/`，不能静默漏记。
+- `.agents/dsh-scaffold.json` 是 tracked bridge 清单；本机运行脚手架的 `pnpm agents:bridge -- connect/doctor --repo <本仓库>` 建立逐项链接。禁止链接整个 `.agents/skills`，以保留本仓库场景版 install。

--- a/skin-manager/README.md
+++ b/skin-manager/README.md
@@ -5,7 +5,7 @@
 - 从当前 Web profile 的依赖中发现所有带有效 `skin.json` 的皮肤；
 - 在官方默认与任意已安装皮肤之间互斥切换；
 - 启动时兜底检测 profile→home 两层的有效启停状态；若两套及以上皮肤会同时启用，原子回退到官方默认；
-- 渲染活动皮肤通过 v1 协议主动暴露的配置项；
+- 渲染活动皮肤通过 v1 协议主动暴露的开关、下拉、复选组、滑杆、颜色与可见时段配置项；
 - 通用的“不那么二次元模式”：按本机时间设置多个显示或隐藏时段。
 
 与皮肤一起，从仓库一行安装（需要 pnpm ≥ 9，`#path:` 子目录语法）：
@@ -31,6 +31,15 @@ const dispose = exposeSkinCustomization({
   title: 'Deepcel',
   settings: [
     { key: 'artwork', type: 'boolean', label: '显示立绘', defaultValue: true },
+    { key: 'accent', type: 'color', label: '强调色', defaultValue: '#ff536f' },
+    {
+      key: 'accentTargets',
+      type: 'checkbox-group',
+      label: '强调目标',
+      defaultValue: [],
+      visibleWhen: { key: 'artwork', values: [true] },
+      options: [{ value: 'title', label: '标题' }, { value: 'frame', label: '边框' }],
+    },
     {
       key: 'sfwMode',
       type: 'visibility-schedule',
@@ -44,5 +53,7 @@ const dispose = exposeSkinCustomization({
   },
 })
 ```
+
+`visibleWhen` 按另一设置的当前值决定是否渲染依赖项；`legacyValue` 可在新键尚未写入时把旧键值映射为新默认值，用于无损拆分已有设置。复选组的值按声明中的 option 顺序保存为字符串数组。
 
 皮肤必须持有并清理自己的 DOM、CSS、observer、listener 与 timer；管理器只处理声明、持久化和时间规则，不了解皮肤内部选择器。`exposeSkinCustomization()` 的返回值应注册到皮肤的 Cordis effect disposer。

--- a/skin-manager/lib/client.js
+++ b/skin-manager/lib/client.js
@@ -174,7 +174,7 @@ window.__ModuleLoader__.load({
 		}
 		//#endregion
 		//#region \0dsh-css:../skin-manager/src/client/skin-manager.module.css.mjs
-		const css = ".orL4ja_section{color:var(--dsw-alias-label-primary);gap:14px;display:grid}.orL4ja_header h2,.orL4ja_card h3,.orL4ja_header p,.orL4ja_error{margin:0}.orL4ja_header{gap:6px;display:grid}.orL4ja_header p{color:var(--dsw-alias-label-secondary);font-size:13px;line-height:1.6}.orL4ja_card{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);border-radius:10px;gap:10px;padding:14px;display:grid}.orL4ja_card h3{font-size:14px}.orL4ja_cardHeader{justify-content:space-between;align-items:center;gap:10px;display:flex}.orL4ja_checkButton{min-height:28px;color:var(--dsw-alias-label-secondary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:6px;padding:4px 12px;font-size:12px}.orL4ja_checkButton:hover:not(:disabled){color:var(--dsw-alias-label-primary);border-color:var(--dsw-alias-brand-primary)}.orL4ja_checkButton:disabled{opacity:.55;cursor:default}.orL4ja_skinTile{align-self:start;gap:4px;min-width:0;display:grid}.orL4ja_skinGrid{grid-template-columns:repeat(auto-fill,minmax(160px,1fr));align-items:start;gap:8px;display:grid}.orL4ja_skinButton{width:100%}.orL4ja_defaultButton,.orL4ja_defaultActive{width:100%;min-height:44px;color:var(--dsw-alias-label-primary);border:1px dashed var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:8px;justify-content:space-between;align-items:center;gap:12px;padding:8px 12px;display:flex}.orL4ja_defaultButton>span,.orL4ja_defaultActive>span{text-align:left;gap:2px;display:grid}.orL4ja_defaultButton small,.orL4ja_defaultActive small{color:var(--dsw-alias-label-tertiary)}.orL4ja_defaultButton:disabled,.orL4ja_defaultActive:disabled{opacity:.75;cursor:default}.orL4ja_defaultActive{border-style:solid;border-color:var(--dsw-alias-brand-primary);box-shadow:inset 3px 0 var(--dsw-alias-brand-primary)}.orL4ja_defaultState{flex:none;color:var(--dsw-alias-label-secondary)!important}.orL4ja_skinButton,.orL4ja_activeSkin{min-height:58px;color:var(--dsw-alias-label-primary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:8px;justify-items:start;gap:3px;padding:10px;display:grid}.orL4ja_activeSkin{border-color:var(--dsw-alias-brand-primary);box-shadow:inset 3px 0 var(--dsw-alias-brand-primary)}.orL4ja_skinButton small,.orL4ja_activeSkin small{color:var(--dsw-alias-label-tertiary)}.orL4ja_versionRow{flex-wrap:wrap;align-items:center;gap:3px 8px;min-height:16px;padding-inline:2px;font-size:11px;line-height:1.5;display:flex}.orL4ja_compatibility{color:var(--dsw-alias-label-tertiary);padding-inline:2px;font-size:11px}.orL4ja_versionHash{appearance:none;color:var(--dsw-alias-label-secondary);font-family:var(--ds-font-family-code,ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);font-size:inherit;line-height:inherit;cursor:pointer;white-space:nowrap;background:0 0;border:0;padding:0}.orL4ja_versionHash:hover{color:var(--dsw-alias-brand-primary)}.orL4ja_versionMuted{color:var(--dsw-alias-label-tertiary)}.orL4ja_versionOk{color:var(--dsw-alias-state-success-primary,#12a150)}.orL4ja_versionUpdate{color:var(--dsw-alias-state-warn-primary,#e08700)}.orL4ja_toggleRow,.orL4ja_selectRow,.orL4ja_sliderRow{justify-content:space-between;align-items:center;gap:12px;min-height:34px;display:flex}.orL4ja_toggleRow>span,.orL4ja_selectRow>span,.orL4ja_sliderRow>span{gap:2px;display:grid}.orL4ja_toggleRow small,.orL4ja_selectRow small,.orL4ja_sliderRow small,.orL4ja_hint{color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:1.5}.orL4ja_toggleRow input{block-size:18px;inline-size:34px;accent-color:var(--dsw-alias-brand-primary)}.orL4ja_toggleSwitch{cursor:pointer;border-radius:999px;flex:none;justify-content:center;align-items:center;margin:-4px;padding:4px;display:inline-flex}.orL4ja_toggleSwitch input,.orL4ja_selectRow select,.orL4ja_rangeRow select{cursor:pointer}.orL4ja_selectRow select,.orL4ja_rangeRow input,.orL4ja_rangeRow select{box-sizing:border-box;min-height:30px;color:var(--dsw-alias-label-primary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-specific-input-major);border-radius:6px}.orL4ja_selectRow select{max-width:240px;padding-inline:8px}.orL4ja_selectRow select:disabled,.orL4ja_sliderRow input:disabled,.orL4ja_toggleRow input:disabled{opacity:.45;cursor:not-allowed}.orL4ja_sliderRow{grid-template-columns:minmax(0,1fr) auto minmax(120px,220px);align-items:center;gap:10px;min-height:40px;display:grid}.orL4ja_sliderValue{min-width:3ch;color:var(--dsw-alias-label-secondary);font-variant-numeric:tabular-nums;text-align:right}.orL4ja_sliderRow input[type=range]{-webkit-appearance:none;appearance:none;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-specific-input-major);cursor:pointer;width:100%;height:20px;image-rendering:pixelated;border-radius:0;margin:0;padding:0}.orL4ja_sliderRow input[type=range]::-webkit-slider-runnable-track{border:1px solid var(--dsw-alias-brand-primary);background:linear-gradient(#bdf6ff,#52bce2 55%,#3716b1);border-radius:0;height:8px}.orL4ja_sliderRow input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;border:2px solid var(--dsw-alias-brand-primary);background:#ff70c8;border-radius:0;width:14px;height:22px;margin-top:-8px;box-shadow:2px 2px #5127ff59}.orL4ja_sliderRow input[type=range]::-moz-range-track{border:1px solid var(--dsw-alias-brand-primary);background:linear-gradient(#bdf6ff,#52bce2 55%,#3716b1);border-radius:0;height:8px}.orL4ja_sliderRow input[type=range]::-moz-range-thumb{border:2px solid var(--dsw-alias-brand-primary);background:#ff70c8;border-radius:0;width:10px;height:18px;box-shadow:2px 2px #5127ff59}.orL4ja_timeSelect{align-items:center;gap:4px;width:100%;min-width:0;display:inline-flex}.orL4ja_timeSelect select{text-align:center;width:100%;min-width:0;max-width:none;padding-inline:6px}.orL4ja_timeColon{color:var(--dsw-alias-label-tertiary);flex:none}.orL4ja_schedule{gap:8px;display:grid}.orL4ja_scheduleDetails{border-left:2px solid var(--dsw-alias-border-l2);gap:8px;margin-left:12px;padding:10px;display:grid}.orL4ja_rangeList{gap:6px;display:grid}.orL4ja_rangeRow{color:var(--dsw-alias-label-secondary);grid-template-columns:minmax(100px,1fr) auto minmax(100px,1fr) auto;align-items:center;gap:8px;font-size:12px;display:grid}.orL4ja_rangeRow input{width:100%;padding-inline:7px}.orL4ja_rangeRow button,.orL4ja_addRange{min-height:30px;color:var(--dsw-alias-label-secondary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:6px;padding:4px 9px}.orL4ja_addRange{justify-self:start}.orL4ja_error{color:var(--dsw-alias-state-danger,#c43d3d);font-size:12px}@media (width<=720px){.orL4ja_skinGrid{grid-template-columns:1fr}.orL4ja_rangeRow{grid-template-columns:1fr auto 1fr}.orL4ja_rangeRow button{grid-column:1/-1;justify-self:end}}";
+		const css = ".orL4ja_section{color:var(--dsw-alias-label-primary);gap:14px;display:grid}.orL4ja_header h2,.orL4ja_card h3,.orL4ja_header p,.orL4ja_error{margin:0}.orL4ja_header{gap:6px;display:grid}.orL4ja_header p{color:var(--dsw-alias-label-secondary);font-size:13px;line-height:1.6}.orL4ja_card{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);border-radius:10px;gap:10px;padding:14px;display:grid}.orL4ja_card h3{font-size:14px}.orL4ja_cardHeader{justify-content:space-between;align-items:center;gap:10px;display:flex}.orL4ja_checkButton{min-height:28px;color:var(--dsw-alias-label-secondary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:6px;padding:4px 12px;font-size:12px}.orL4ja_checkButton:hover:not(:disabled){color:var(--dsw-alias-label-primary);border-color:var(--dsw-alias-brand-primary)}.orL4ja_checkButton:disabled{opacity:.55;cursor:default}.orL4ja_skinTile{align-self:start;gap:4px;min-width:0;display:grid}.orL4ja_skinGrid{grid-template-columns:repeat(auto-fill,minmax(160px,1fr));align-items:start;gap:8px;display:grid}.orL4ja_skinButton{width:100%}.orL4ja_defaultButton,.orL4ja_defaultActive{width:100%;min-height:44px;color:var(--dsw-alias-label-primary);border:1px dashed var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:8px;justify-content:space-between;align-items:center;gap:12px;padding:8px 12px;display:flex}.orL4ja_defaultButton>span,.orL4ja_defaultActive>span{text-align:left;gap:2px;display:grid}.orL4ja_defaultButton small,.orL4ja_defaultActive small{color:var(--dsw-alias-label-tertiary)}.orL4ja_defaultButton:disabled,.orL4ja_defaultActive:disabled{opacity:.75;cursor:default}.orL4ja_defaultActive{border-style:solid;border-color:var(--dsw-alias-brand-primary);box-shadow:inset 3px 0 var(--dsw-alias-brand-primary)}.orL4ja_defaultState{flex:none;color:var(--dsw-alias-label-secondary)!important}.orL4ja_skinButton,.orL4ja_activeSkin{min-height:58px;color:var(--dsw-alias-label-primary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:8px;justify-items:start;gap:3px;padding:10px;display:grid}.orL4ja_activeSkin{border-color:var(--dsw-alias-brand-primary);box-shadow:inset 3px 0 var(--dsw-alias-brand-primary)}.orL4ja_skinButton small,.orL4ja_activeSkin small{color:var(--dsw-alias-label-tertiary)}.orL4ja_versionRow{flex-wrap:wrap;align-items:center;gap:3px 8px;min-height:16px;padding-inline:2px;font-size:11px;line-height:1.5;display:flex}.orL4ja_compatibility{color:var(--dsw-alias-label-tertiary);padding-inline:2px;font-size:11px}.orL4ja_versionHash{appearance:none;color:var(--dsw-alias-label-secondary);font-family:var(--ds-font-family-code,ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);font-size:inherit;line-height:inherit;cursor:pointer;white-space:nowrap;background:0 0;border:0;padding:0}.orL4ja_versionHash:hover{color:var(--dsw-alias-brand-primary)}.orL4ja_versionMuted{color:var(--dsw-alias-label-tertiary)}.orL4ja_versionOk{color:var(--dsw-alias-state-success-primary,#12a150)}.orL4ja_versionUpdate{color:var(--dsw-alias-state-warn-primary,#e08700)}.orL4ja_toggleRow,.orL4ja_selectRow,.orL4ja_sliderRow,.orL4ja_colorRow{justify-content:space-between;align-items:center;gap:12px;min-height:34px;display:flex}.orL4ja_toggleRow>span,.orL4ja_selectRow>span,.orL4ja_sliderRow>span,.orL4ja_colorRow>span{gap:2px;display:grid}.orL4ja_toggleRow small,.orL4ja_selectRow small,.orL4ja_sliderRow small,.orL4ja_colorRow small,.orL4ja_checkboxGroup small,.orL4ja_hint{color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:1.5}.orL4ja_toggleRow input{block-size:18px;inline-size:34px;accent-color:var(--dsw-alias-brand-primary)}.orL4ja_toggleSwitch{cursor:pointer;border-radius:999px;flex:none;justify-content:center;align-items:center;margin:-4px;padding:4px;display:inline-flex}.orL4ja_toggleSwitch input,.orL4ja_selectRow select,.orL4ja_rangeRow select{cursor:pointer}.orL4ja_selectRow select,.orL4ja_rangeRow input,.orL4ja_rangeRow select{box-sizing:border-box;min-height:30px;color:var(--dsw-alias-label-primary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-specific-input-major);border-radius:6px}.orL4ja_selectRow select{max-width:240px;padding-inline:8px}.orL4ja_selectRow select:disabled,.orL4ja_sliderRow input:disabled,.orL4ja_colorRow input:disabled,.orL4ja_toggleRow input:disabled{opacity:.45;cursor:not-allowed}.orL4ja_colorControl{flex:none;grid-auto-flow:column;align-items:center;gap:8px!important;display:flex!important}.orL4ja_colorControl code{min-width:7ch;color:var(--dsw-alias-label-secondary);font-family:ui-monospace,monospace;font-size:12px}.orL4ja_colorControl input[type=color]{appearance:none;box-sizing:border-box;cursor:pointer;background:0 0;border:0;border-radius:0;width:38px;height:24px;padding:0}.orL4ja_colorWell{border:1px solid var(--dsw-alias-brand-primary);background:var(--dsw-specific-input-major);border-radius:2px;padding:3px;display:inline-flex;box-shadow:inset 1px 1px #ffffffb3,inset -1px -1px #0000003d,2px 2px #5127ff47}.orL4ja_colorWell:focus-within{outline:1px solid var(--dsw-alias-brand-primary);outline-offset:2px}.orL4ja_colorControl input[type=color]::-webkit-color-swatch-wrapper{padding:2px}.orL4ja_colorControl input[type=color]::-webkit-color-swatch{border:1px solid #0000006b;border-radius:0}.orL4ja_colorControl input[type=color]::-moz-color-swatch{border:1px solid #0000006b;border-radius:0}.orL4ja_checkboxGroup{border-left:2px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);gap:8px;margin-left:12px;padding:10px 12px 12px;display:grid}.orL4ja_checkboxGroupHeading{gap:2px;display:grid}.orL4ja_checkboxGrid{grid-template-columns:repeat(auto-fit,minmax(72px,1fr));gap:6px 12px;display:grid}.orL4ja_checkboxOption{cursor:pointer;align-items:center;gap:6px;min-height:24px;display:inline-flex}.orL4ja_checkboxOption input{block-size:16px;inline-size:16px;accent-color:var(--dsw-alias-brand-primary);cursor:pointer;margin:0}.orL4ja_checkboxOption input:disabled{opacity:.45;cursor:not-allowed}.orL4ja_sliderRow{grid-template-columns:minmax(0,1fr) auto minmax(120px,220px);align-items:center;gap:10px;min-height:40px;display:grid}.orL4ja_sliderValue{min-width:3ch;color:var(--dsw-alias-label-secondary);font-variant-numeric:tabular-nums;text-align:right}.orL4ja_sliderRow input[type=range]{-webkit-appearance:none;appearance:none;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-specific-input-major);cursor:pointer;width:100%;height:20px;image-rendering:pixelated;border-radius:0;margin:0;padding:0}.orL4ja_sliderRow input[type=range]::-webkit-slider-runnable-track{border:1px solid var(--dsw-alias-brand-primary);background:linear-gradient(#bdf6ff,#52bce2 55%,#3716b1);border-radius:0;height:8px}.orL4ja_sliderRow input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;border:2px solid var(--dsw-alias-brand-primary);background:#ff70c8;border-radius:0;width:14px;height:22px;margin-top:-8px;box-shadow:2px 2px #5127ff59}.orL4ja_sliderRow input[type=range]::-moz-range-track{border:1px solid var(--dsw-alias-brand-primary);background:linear-gradient(#bdf6ff,#52bce2 55%,#3716b1);border-radius:0;height:8px}.orL4ja_sliderRow input[type=range]::-moz-range-thumb{border:2px solid var(--dsw-alias-brand-primary);background:#ff70c8;border-radius:0;width:10px;height:18px;box-shadow:2px 2px #5127ff59}.orL4ja_timeSelect{align-items:center;gap:4px;width:100%;min-width:0;display:inline-flex}.orL4ja_timeSelect select{text-align:center;width:100%;min-width:0;max-width:none;padding-inline:6px}.orL4ja_timeColon{color:var(--dsw-alias-label-tertiary);flex:none}.orL4ja_schedule{gap:8px;display:grid}.orL4ja_scheduleDetails{border-left:2px solid var(--dsw-alias-border-l2);gap:8px;margin-left:12px;padding:10px;display:grid}.orL4ja_rangeList{gap:6px;display:grid}.orL4ja_rangeRow{color:var(--dsw-alias-label-secondary);grid-template-columns:minmax(100px,1fr) auto minmax(100px,1fr) auto;align-items:center;gap:8px;font-size:12px;display:grid}.orL4ja_rangeRow input{width:100%;padding-inline:7px}.orL4ja_rangeRow button,.orL4ja_addRange{min-height:30px;color:var(--dsw-alias-label-secondary);border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);cursor:pointer;border-radius:6px;padding:4px 9px}.orL4ja_addRange{justify-self:start}.orL4ja_error{color:var(--dsw-alias-state-danger,#c43d3d);font-size:12px}@media (width<=720px){.orL4ja_skinGrid{grid-template-columns:1fr}.orL4ja_rangeRow{grid-template-columns:1fr auto 1fr}.orL4ja_rangeRow button{grid-column:1/-1;justify-self:end}}";
 		const tagId = "@dsh-external/dsh-client-ui-skin-deep-whale-manager/skin-manager.module.css";
 		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
 			const tag = document.createElement("style");
@@ -189,6 +189,13 @@ window.__ModuleLoader__.load({
 			"card": "orL4ja_card",
 			"cardHeader": "orL4ja_cardHeader",
 			"checkButton": "orL4ja_checkButton",
+			"checkboxGrid": "orL4ja_checkboxGrid",
+			"checkboxGroup": "orL4ja_checkboxGroup",
+			"checkboxGroupHeading": "orL4ja_checkboxGroupHeading",
+			"checkboxOption": "orL4ja_checkboxOption",
+			"colorControl": "orL4ja_colorControl",
+			"colorRow": "orL4ja_colorRow",
+			"colorWell": "orL4ja_colorWell",
 			"compatibility": "orL4ja_compatibility",
 			"defaultActive": "orL4ja_defaultActive",
 			"defaultButton": "orL4ja_defaultButton",
@@ -435,6 +442,35 @@ window.__ModuleLoader__.load({
 				]
 			});
 		}
+		function CheckboxGroupEditor({ setting, label, description, value, disabled = false, onChange }) {
+			const lang = useUiLang();
+			const selected = new Set(value);
+			const update = (option, checked) => {
+				if (checked) selected.add(option);
+				else selected.delete(option);
+				onChange(setting.options.map((item) => item.value).filter((item) => selected.has(item)));
+			};
+			return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("div", {
+				className: skin_manager_module_css_default.checkboxGroup,
+				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("span", {
+					className: skin_manager_module_css_default.checkboxGroupHeading,
+					children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", { children: label }), description && /* @__PURE__ */ (0, react_jsx_runtime.jsx)("small", { children: description })]
+				}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("div", {
+					className: skin_manager_module_css_default.checkboxGrid,
+					role: "group",
+					"aria-label": label,
+					children: setting.options.map((option) => /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("label", {
+						className: skin_manager_module_css_default.checkboxOption,
+						children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("input", {
+							type: "checkbox",
+							checked: selected.has(option.value),
+							disabled,
+							onChange: (event) => update(option.value, event.currentTarget.checked)
+						}), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", { children: optionLabel(option, lang) })]
+					}, option.value))
+				})]
+			});
+		}
 		function SettingEditor({ setting, value, disabled = false, onChange }) {
 			const lang = useUiLang();
 			const label = settingLabel(setting, lang);
@@ -466,11 +502,41 @@ window.__ModuleLoader__.load({
 				disabled,
 				onChange
 			});
+			if (setting.type === "color") return /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("label", {
+				className: skin_manager_module_css_default.colorRow,
+				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("span", { children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", { children: label }), description && /* @__PURE__ */ (0, react_jsx_runtime.jsx)("small", { children: description })] }), /* @__PURE__ */ (0, react_jsx_runtime.jsxs)("span", {
+					className: skin_manager_module_css_default.colorControl,
+					children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("code", { children: String(value).toUpperCase() }), /* @__PURE__ */ (0, react_jsx_runtime.jsx)("span", {
+						className: skin_manager_module_css_default.colorWell,
+						children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)("input", {
+							type: "color",
+							value,
+							disabled,
+							"aria-label": label,
+							onChange: (event) => onChange(event.currentTarget.value)
+						})
+					})]
+				})]
+			});
+			if (setting.type === "checkbox-group") return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(CheckboxGroupEditor, {
+				setting,
+				label,
+				description,
+				value,
+				disabled,
+				onChange
+			});
 			return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(ScheduleEditor, {
 				setting,
 				value,
 				onChange
 			});
+		}
+		function settingVisible(setting, values) {
+			const condition = setting.visibleWhen;
+			if (condition === void 0) return true;
+			const value = values[condition.key];
+			return condition.values.some((candidate) => candidate === value);
 		}
 		function CustomizationCard({ definition, registry }) {
 			const lang = useUiLang();
@@ -479,6 +545,7 @@ window.__ModuleLoader__.load({
 				className: skin_manager_module_css_default.card,
 				"data-skin-customization": definition.skinId,
 				children: [/* @__PURE__ */ (0, react_jsx_runtime.jsx)("h3", { children: definitionTitle(definition, lang) }), definition.settings.map((setting) => {
+					if (!settingVisible(setting, values)) return null;
 					const disabled = setting.disabledWhen !== void 0 && values[setting.disabledWhen] === true;
 					return /* @__PURE__ */ (0, react_jsx_runtime.jsx)(SettingEditor, {
 						setting,
@@ -792,11 +859,25 @@ window.__ModuleLoader__.load({
 				const max = setting.max;
 				return Math.min(max, Math.max(min, numeric));
 			}
+			if (setting.type === "color") return typeof value === "string" && /^#[0-9a-f]{6}$/i.test(value) ? value.toLowerCase() : setting.defaultValue;
+			if (setting.type === "checkbox-group") {
+				const selected = new Set(Array.isArray(value) ? value : setting.defaultValue);
+				return setting.options.map((option) => option.value).filter((option) => selected.has(option));
+			}
 			return normalizeVisibilitySchedule(value, setting.defaultValue);
+		}
+		function settingSourceValue(setting, source) {
+			if (Object.hasOwn(source, setting.key)) return source[setting.key];
+			const legacy = setting.legacyValue;
+			if (legacy === void 0) return void 0;
+			const legacyValue = source[legacy.key];
+			if (typeof legacyValue !== "boolean" && typeof legacyValue !== "string" && typeof legacyValue !== "number") return;
+			const key = String(legacyValue);
+			return Object.hasOwn(legacy.map, key) ? legacy.map[key] : void 0;
 		}
 		function normalizeSkinValues(definition, value) {
 			const source = object(value);
-			return Object.fromEntries(definition.settings.map((setting) => [setting.key, normalizeSetting(setting, source[setting.key])]));
+			return Object.fromEntries(definition.settings.map((setting) => [setting.key, normalizeSetting(setting, settingSourceValue(setting, source))]));
 		}
 		var PreferencesStore = class {
 			storage;

--- a/skin-manager/lib/index.js
+++ b/skin-manager/lib/index.js
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 //#region src/contract.ts
 /** Same-origin host route used for catalog discovery and activation. */
@@ -26,10 +27,26 @@ function resolveProfilePatch(env = process.env, cwd = process.cwd()) {
 	if (!/^[a-zA-Z0-9._-]+$/.test(profile)) throw new Error("invalid-profile-name");
 	return join(profilesDir, profile, "cordis.patch.yml");
 }
+/** Resolve the running profile from the root Loader base before using process-level fallbacks. */
+function resolveRuntimeProfilePatch(baseUrl, env = process.env, cwd = process.cwd()) {
+	if (baseUrl !== void 0) try {
+		const baseDir = resolve(fileURLToPath(baseUrl));
+		if (basename(dirname(baseDir)) === "profiles") {
+			const profile = basename(baseDir);
+			if (!/^[a-zA-Z0-9._-]+$/.test(profile)) throw new Error("invalid-profile-name");
+			return join(baseDir, "cordis.patch.yml");
+		}
+	} catch (error) {
+		if (error instanceof Error && error.message === "invalid-profile-name") throw error;
+	}
+	return resolveProfilePatch(env, cwd);
+}
+function patchTargetsForProfile(profilePatch) {
+	return [profilePatch, join(dirname(dirname(dirname(profilePatch))), "cordis.patch.yml")];
+}
 /** Both live user layers must agree because the home layer has higher priority. */
 function resolvePatchTargets(env = process.env, cwd = process.cwd()) {
-	const profilePatch = resolveProfilePatch(env, cwd);
-	return [profilePatch, join(dirname(dirname(dirname(profilePatch))), "cordis.patch.yml")];
+	return patchTargetsForProfile(resolveProfilePatch(env, cwd));
 }
 function packageNames(manifestPath) {
 	try {
@@ -738,14 +755,17 @@ function makeSkinManagerRoute(catalogProvider = () => discoverInstalledSkins(), 
 }
 /** Register the switching route with lifecycle-owned cleanup. */
 function apply(ctx) {
+	const profilePatch = resolveRuntimeProfilePatch(ctx.baseUrl);
+	const patchPaths = patchTargetsForProfile(profilePatch);
+	const catalog = () => discoverInstalledSkins(profilePatch);
 	ctx.effect(() => {
 		try {
-			ensureSafeInitialState();
+			ensureSafeInitialState(patchPaths, catalog());
 		} catch (error) {
 			console.error("[skin-manager] failed to enforce startup mutual exclusion", error);
 		}
-		return ctx.webServer.register(makeSkinManagerRoute(void 0, void 0, () => discoverSkinDirectories()));
+		return ctx.webServer.register(makeSkinManagerRoute(catalog, (target, installed) => useSkin(target, patchPaths, installed), () => discoverSkinDirectories(profilePatch)));
 	}, "ui-skin-manager: startup guard and catalog/activation route");
 }
 //#endregion
-export { MANAGED_END, MANAGED_START, SKIN_CUSTOMIZATION_PROTOCOL, SKIN_CUSTOMIZATION_READY_EVENT, SKIN_CUSTOMIZATION_REGISTER_EVENT, SKIN_CUSTOMIZATION_UNREGISTER_EVENT, SKIN_MANAGER_ROUTE, SkinAttributeProjector, apply, classifyUpdate, computeSkinFingerprint, discoverInstalledSkins, discoverSkinDirectories, enabledSkins, ensureSafeInitialState, exposeSkinCustomization, inject, inspectInstalledVersion, inspectSkinVersion, makeSkinManagerRoute, name, parseGitHubRemote, readSkinBuildMeta, readSkinStates, renderManagedBlock, repositoryRelativePath, resolvePatchTargets, resolveProfilePatch, stripManagedBlock, switchPatch, useSkin };
+export { MANAGED_END, MANAGED_START, SKIN_CUSTOMIZATION_PROTOCOL, SKIN_CUSTOMIZATION_READY_EVENT, SKIN_CUSTOMIZATION_REGISTER_EVENT, SKIN_CUSTOMIZATION_UNREGISTER_EVENT, SKIN_MANAGER_ROUTE, SkinAttributeProjector, apply, classifyUpdate, computeSkinFingerprint, discoverInstalledSkins, discoverSkinDirectories, enabledSkins, ensureSafeInitialState, exposeSkinCustomization, inject, inspectInstalledVersion, inspectSkinVersion, makeSkinManagerRoute, name, parseGitHubRemote, readSkinBuildMeta, readSkinStates, renderManagedBlock, repositoryRelativePath, resolvePatchTargets, resolveProfilePatch, resolveRuntimeProfilePatch, stripManagedBlock, switchPatch, useSkin };

--- a/skin-manager/src/client/SkinManager.tsx
+++ b/skin-manager/src/client/SkinManager.tsx
@@ -220,6 +220,46 @@ function RangeEditor({ setting, label, description, value, disabled = false, onC
   )
 }
 
+function CheckboxGroupEditor({ setting, label, description, value, disabled = false, onChange }: {
+  setting: Extract<SkinSetting, { type: 'checkbox-group' }>
+  label: string
+  description?: string
+  value: string[]
+  disabled?: boolean
+  onChange(value: string[]): void
+}) {
+  const lang = useUiLang()
+  const selected = new Set(value)
+  const update = (option: string, checked: boolean): void => {
+    if (checked) selected.add(option)
+    else selected.delete(option)
+    onChange(setting.options
+      .map(item => item.value)
+      .filter(item => selected.has(item)))
+  }
+  return (
+    <div className={css.checkboxGroup}>
+      <span className={css.checkboxGroupHeading}>
+        <span>{label}</span>
+        {description && <small>{description}</small>}
+      </span>
+      <div className={css.checkboxGrid} role="group" aria-label={label}>
+        {setting.options.map(option => (
+          <label className={css.checkboxOption} key={option.value}>
+            <input
+              type="checkbox"
+              checked={selected.has(option.value)}
+              disabled={disabled}
+              onChange={event => update(option.value, event.currentTarget.checked)}
+            />
+            <span>{optionLabel(option, lang)}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function SettingEditor({ setting, value, disabled = false, onChange }: {
   setting: SkinSetting
   value: SkinSettingValue
@@ -248,7 +288,48 @@ function SettingEditor({ setting, value, disabled = false, onChange }: {
   if (setting.type === 'range') {
     return <RangeEditor setting={setting} label={label} description={description} value={value as number} disabled={disabled} onChange={onChange} />
   }
+  if (setting.type === 'color') {
+    return (
+      <label className={css.colorRow}>
+        <span>
+          <span>{label}</span>
+          {description && <small>{description}</small>}
+        </span>
+        <span className={css.colorControl}>
+          <code>{String(value).toUpperCase()}</code>
+          <span className={css.colorWell}>
+            <input
+              type="color"
+              value={value as string}
+              disabled={disabled}
+              aria-label={label}
+              onChange={event => onChange(event.currentTarget.value)}
+            />
+          </span>
+        </span>
+      </label>
+    )
+  }
+  if (setting.type === 'checkbox-group') {
+    return (
+      <CheckboxGroupEditor
+        setting={setting}
+        label={label}
+        description={description}
+        value={value as string[]}
+        disabled={disabled}
+        onChange={onChange}
+      />
+    )
+  }
   return <ScheduleEditor setting={setting} value={value as VisibilitySchedule} onChange={onChange} />
+}
+
+function settingVisible(setting: SkinSetting, values: Record<string, SkinSettingValue>): boolean {
+  const condition = setting.visibleWhen
+  if (condition === undefined) return true
+  const value = values[condition.key]
+  return condition.values.some(candidate => candidate === value)
 }
 
 function CustomizationCard({ definition, registry }: {
@@ -261,6 +342,7 @@ function CustomizationCard({ definition, registry }: {
     <section className={css.card} data-skin-customization={definition.skinId}>
       <h3>{definitionTitle(definition, lang)}</h3>
       {definition.settings.map(setting => {
+        if (!settingVisible(setting, values)) return null
         const disabled = setting.disabledWhen !== undefined && values[setting.disabledWhen] === true
         return (
           <SettingEditor

--- a/skin-manager/src/client/preferences.ts
+++ b/skin-manager/src/client/preferences.ts
@@ -55,7 +55,30 @@ function normalizeSetting(setting: SkinSetting, value: unknown): SkinSettingValu
     const max = setting.max
     return Math.min(max, Math.max(min, numeric))
   }
+  if (setting.type === 'color') {
+    return typeof value === 'string' && /^#[0-9a-f]{6}$/i.test(value)
+      ? value.toLowerCase()
+      : setting.defaultValue
+  }
+  if (setting.type === 'checkbox-group') {
+    const selected = new Set(Array.isArray(value) ? value : setting.defaultValue)
+    return setting.options
+      .map(option => option.value)
+      .filter(option => selected.has(option))
+  }
   return normalizeVisibilitySchedule(value, setting.defaultValue)
+}
+
+function settingSourceValue(setting: SkinSetting, source: Record<string, unknown>): unknown {
+  if (Object.hasOwn(source, setting.key)) return source[setting.key]
+  const legacy = setting.legacyValue
+  if (legacy === undefined) return undefined
+  const legacyValue = source[legacy.key]
+  if (typeof legacyValue !== 'boolean' && typeof legacyValue !== 'string' && typeof legacyValue !== 'number') {
+    return undefined
+  }
+  const key = String(legacyValue)
+  return Object.hasOwn(legacy.map, key) ? legacy.map[key] : undefined
 }
 
 export function normalizeSkinValues(
@@ -65,7 +88,7 @@ export function normalizeSkinValues(
   const source = object(value)
   return Object.fromEntries(definition.settings.map(setting => [
     setting.key,
-    normalizeSetting(setting, source[setting.key]),
+    normalizeSetting(setting, settingSourceValue(setting, source)),
   ]))
 }
 

--- a/skin-manager/src/client/skin-manager.module.css
+++ b/skin-manager/src/client/skin-manager.module.css
@@ -203,7 +203,8 @@
 
 .toggleRow,
 .selectRow,
-.sliderRow {
+.sliderRow,
+.colorRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -213,7 +214,8 @@
 
 .toggleRow > span,
 .selectRow > span,
-.sliderRow > span {
+.sliderRow > span,
+.colorRow > span {
   display: grid;
   gap: 2px;
 }
@@ -221,6 +223,8 @@
 .toggleRow small,
 .selectRow small,
 .sliderRow small,
+.colorRow small,
+.checkboxGroup small,
 .hint {
   color: var(--dsw-alias-label-tertiary);
   font-size: 12px;
@@ -278,7 +282,107 @@
  * visually disabled but keep their value for when the dependency is toggled off. */
 .selectRow select:disabled,
 .sliderRow input:disabled,
+.colorRow input:disabled,
 .toggleRow input:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.colorControl {
+  display: flex !important;
+  flex: none;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: 8px !important;
+}
+
+.colorControl code {
+  min-width: 7ch;
+  color: var(--dsw-alias-label-secondary);
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+
+.colorControl input[type='color'] {
+  appearance: none;
+  box-sizing: border-box;
+  width: 38px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.colorWell {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid var(--dsw-alias-brand-primary);
+  border-radius: 2px;
+  background: var(--dsw-specific-input-major);
+  box-shadow:
+    inset 1px 1px 0 rgb(255 255 255 / 70%),
+    inset -1px -1px 0 rgb(0 0 0 / 24%),
+    2px 2px 0 rgb(81 39 255 / 28%);
+}
+
+.colorWell:focus-within {
+  outline: 1px solid var(--dsw-alias-brand-primary);
+  outline-offset: 2px;
+}
+
+.colorControl input[type='color']::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.colorControl input[type='color']::-webkit-color-swatch {
+  border: 1px solid rgb(0 0 0 / 42%);
+  border-radius: 0;
+}
+
+.colorControl input[type='color']::-moz-color-swatch {
+  border: 1px solid rgb(0 0 0 / 42%);
+  border-radius: 0;
+}
+
+.checkboxGroup {
+  display: grid;
+  gap: 8px;
+  margin-left: 12px;
+  padding: 10px 12px 12px;
+  border-left: 2px solid var(--dsw-alias-border-l2);
+  background: var(--dsw-alias-bg-layer-2);
+}
+
+.checkboxGroupHeading {
+  display: grid;
+  gap: 2px;
+}
+
+.checkboxGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  gap: 6px 12px;
+}
+
+.checkboxOption {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  cursor: pointer;
+}
+
+.checkboxOption input {
+  inline-size: 16px;
+  block-size: 16px;
+  margin: 0;
+  accent-color: var(--dsw-alias-brand-primary);
+  cursor: pointer;
+}
+
+.checkboxOption input:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }

--- a/skin-manager/src/index.ts
+++ b/skin-manager/src/index.ts
@@ -7,6 +7,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
 import { basename, dirname, join as joinPath, relative as relativePath, resolve as resolvePath } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import { SKIN_MANAGER_ROUTE, type SkinCatalogEntry, type SkinTarget, type SkinUpdateState, type SkinVersionCommit, type SkinVersionInfo, type SkinVersionSource } from './contract.ts'
 
@@ -57,10 +58,34 @@ export function resolveProfilePatch(env: NodeJS.ProcessEnv = process.env, cwd = 
   return joinPath(profilesDir, profile, 'cordis.patch.yml')
 }
 
+/** Resolve the running profile from the root Loader base before using process-level fallbacks. */
+export function resolveRuntimeProfilePatch(
+  baseUrl: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+  cwd = process.cwd(),
+): string {
+  if (baseUrl !== undefined) {
+    try {
+      const baseDir = resolvePath(fileURLToPath(baseUrl))
+      if (basename(dirname(baseDir)) === 'profiles') {
+        const profile = basename(baseDir)
+        if (!/^[a-zA-Z0-9._-]+$/.test(profile)) throw new Error('invalid-profile-name')
+        return joinPath(baseDir, 'cordis.patch.yml')
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message === 'invalid-profile-name') throw error
+    }
+  }
+  return resolveProfilePatch(env, cwd)
+}
+
+function patchTargetsForProfile(profilePatch: string): string[] {
+  return [profilePatch, joinPath(dirname(dirname(dirname(profilePatch))), 'cordis.patch.yml')]
+}
+
 /** Both live user layers must agree because the home layer has higher priority. */
 export function resolvePatchTargets(env: NodeJS.ProcessEnv = process.env, cwd = process.cwd()): string[] {
-  const profilePatch = resolveProfilePatch(env, cwd)
-  return [profilePatch, joinPath(dirname(dirname(dirname(profilePatch))), 'cordis.patch.yml')]
+  return patchTargetsForProfile(resolveProfilePatch(env, cwd))
 }
 
 function packageNames(manifestPath: string): string[] {
@@ -861,12 +886,19 @@ export function makeSkinManagerRoute(
 
 /** Register the switching route with lifecycle-owned cleanup. */
 export function apply(ctx: HostContext): void {
+  const profilePatch = resolveRuntimeProfilePatch(ctx.baseUrl)
+  const patchPaths = patchTargetsForProfile(profilePatch)
+  const catalog = (): SkinCatalogEntry[] => discoverInstalledSkins(profilePatch)
   ctx.effect(() => {
     try {
-      ensureSafeInitialState()
+      ensureSafeInitialState(patchPaths, catalog())
     } catch (error) {
       console.error('[skin-manager] failed to enforce startup mutual exclusion', error)
     }
-    return ctx.webServer.register(makeSkinManagerRoute(undefined, undefined, () => discoverSkinDirectories()))
+    return ctx.webServer.register(makeSkinManagerRoute(
+      catalog,
+      (target, installed) => useSkin(target, patchPaths, installed),
+      () => discoverSkinDirectories(profilePatch),
+    ))
   }, 'ui-skin-manager: startup guard and catalog/activation route')
 }

--- a/skin-manager/src/protocol.ts
+++ b/skin-manager/src/protocol.ts
@@ -19,6 +19,18 @@ export interface VisibilitySchedule {
   ranges: TimeRange[]
 }
 
+export type SkinConditionValue = boolean | string | number
+
+export interface SkinSettingCondition {
+  key: string
+  values: SkinConditionValue[]
+}
+
+export interface LegacySettingValue<T> {
+  key: string
+  map: Record<string, T>
+}
+
 /**
  * Every `*En` field is an optional English variant of its sibling: the
  * manager shows it while the host UI language is English and falls back to
@@ -34,6 +46,10 @@ interface SettingBase<T> {
   defaultValue: T
   /** When this boolean setting key is true, the control becomes disabled. */
   disabledWhen?: string
+  /** Only render this control while the referenced value matches one of these values. */
+  visibleWhen?: SkinSettingCondition
+  /** Use a mapped legacy key only while this setting has no stored value of its own. */
+  legacyValue?: LegacySettingValue<T>
 }
 
 export interface BooleanSetting extends SettingBase<boolean> {
@@ -59,12 +75,21 @@ export interface RangeSetting extends SettingBase<number> {
   unit?: string
 }
 
+export interface ColorSetting extends SettingBase<string> {
+  type: 'color'
+}
+
+export interface CheckboxGroupSetting extends SettingBase<string[]> {
+  type: 'checkbox-group'
+  options: SelectOption[]
+}
+
 export interface VisibilityScheduleSetting extends SettingBase<VisibilitySchedule> {
   type: 'visibility-schedule'
 }
 
-export type SkinSetting = BooleanSetting | SelectSetting | RangeSetting | VisibilityScheduleSetting
-export type SkinSettingValue = boolean | string | number | VisibilitySchedule
+export type SkinSetting = BooleanSetting | SelectSetting | RangeSetting | ColorSetting | CheckboxGroupSetting | VisibilityScheduleSetting
+export type SkinSettingValue = boolean | string | number | string[] | VisibilitySchedule
 export type SkinValues = Record<string, SkinSettingValue>
 
 export interface SkinCustomizationState {


### PR DESCRIPTION
## 关联 Issue

无。本 PR 是已合并 Alpha 适配分支的收尾：整理其后续未提交内容并退役长期 Alpha 分支，没有单一对应 issue。

## 改动内容

- 从 Cordis runtime base 定位实际 Web profile，避免 skin-manager 操作错误 profile。
- 扩展声明式配置协议：颜色、复选组、条件显示与旧键值迁移。
- 接入 dsh-skin-template 的共享 Notes / Host Delta / skill bridge，并同步公开仓库所需的升级 skill 镜像。
- 用户运行时变化仅限 skin-manager；maid-atelier 与 orca-link 源码、样式和产物均未修改。

## 验证

- [ ] 修复/功能类改动附截图或录屏：未运行 GUI/视觉验证。
- [x] 复现/验证步骤：`npm test`（58 tests）→ `npm run build` → skill validator → agent bridge doctor。
- [x] 无关联 issue 的理由：Alpha 分支退役前的已存在收尾改动，不对应新的缺陷报告。

## 兼容性自查（对照 AGENTS.md）

- [x] 生命周期：沿用现有 `ctx.effect()` route disposer；没有新增 DOM observer/listener/timer 所有权。
- [ ] 浅色 / 深色主题均验证：未运行视觉验证。
- [ ] 宽侧栏 / 窄侧栏（rail）均验证：本 PR 不修改两款皮肤；manager 新控件未运行 GUI。
- [ ] 浏览器与桌面壳布局均验证：未运行 GUI。
- [x] 无远程运行时资源依赖。
- [x] `lib/` 已用 skin-manager 当前构建管道重新生成并核对。
- [x] 不涉及素材、作者信息或许可链变化。
- [x] 未新增测试文件；现有 58 个确定性测试全部通过，bridge 的跨平台行为由模板仓库对应 PR 覆盖。