### PR TITLE
feat(mobile): float the collapsed rail above the composer on phones — proposal

### DIFF
--- a/maid-atelier/src/client/index.ts
+++ b/maid-atelier/src/client/index.ts
@@ -44,6 +44,7 @@ import { installMaidComposerCapsule } from './composer-capsule.ts'
 import { installMaidComposerDismiss } from './composer-dismiss.ts'
 import { installMaidComposerScroll } from './composer-scroll.ts'
 import { installMaidMobileDrawerAutoClose } from './mobile-drawer.ts'
+import { installMaidMobileDock } from './mobile-dock.ts'
 import { createMaidSettingsNavigation } from './settings-navigation.ts'
 import { installMaidCustomization } from './customization.ts'
 import { installMaidBootError } from './boot-error.ts'
@@ -556,6 +557,7 @@ export function apply(ctx: Context): void {
   const settingsNavigation = createMaidSettingsNavigation(body)
   ctx.effect(() => settingsNavigation.dispose, 'ui-skin-maid-atelier: settings navigation hint')
   ctx.effect(() => installMaidMobileDrawerAutoClose(body), 'ui-skin-maid-atelier: mobile drawer auto-close')
+  ctx.effect(() => installMaidMobileDock(body), 'ui-skin-maid-atelier: phone dock geometry')
   disposeMaidTableCards = installMaidTableCards(ctx).dispose
   body.style.setProperty('--maid-top-trim-art', `url(${MAID_ATELIER_TOP_TRIM_TILE})`)
   body.style.setProperty('--maid-boot-error-left-art', `url(${MAID_BOOT_ERROR_LEFT})`)

--- a/maid-atelier/src/client/maid-atelier.module.css
+++ b/maid-atelier/src/client/maid-atelier.module.css
@@ -1500,6 +1500,182 @@ body[data-dsh-maid-atelier][data-maid-sidebar-size='rail']
   box-shadow: none;
 }
 
+/* ---------------------------------------------------------------------------
+   Phone chrome: the collapsed column becomes a floating brand dock.
+
+   The host pins its collapsed rail to the left edge as a 56px column, so on a
+   390x844 phone the conversation column measures 334px and loses 14% of the
+   width to a strip whose only always-useful control is the toggle that opens
+   the column. Under 700px portrait that column leaves the layout entirely: the
+   conversation owns the whole viewport and the toggle — drawn as the product's
+   own brand mark — floats above the composer's top-left corner, inside thumb
+   reach. New Session, the panel buttons and Settings stay one tap away in the
+   drawer the dock opens.
+
+   Hooks: `data-sidebar-collapsed` on the AppFrame is the host's own marker for
+   "the column is the rail", `sidebarCol` is the class the rest of this file
+   already matches on, and `logoRow` / `toggle` are the host's names. The
+   `@supports` arm covers engines without relational selectors. The client entry
+   publishes `--maid-dock-offset` from the composer's measured top edge, so the
+   dock tracks a composer that grows and a software keyboard that shrinks the
+   viewport; the fallback clears the home indicator without it. An expanded
+   column (no `data-sidebar-collapsed`) keeps the overlay drawer below.
+
+   Landscape is untouched: there the scarce axis is height, so the rail's 56px
+   of width is the cheaper trade. */
+@media (max-width: 700px) and (orientation: portrait) {
+  /* Frame: the conversation is the only in-flow child. */
+  body[data-dsh-maid-atelier] div[data-sidebar-collapsed] {
+    display: flex !important;
+    flex-direction: column !important;
+    grid-template-columns: none !important;
+    grid-template-rows: none !important;
+    height: 100% !important;
+    min-height: 0 !important;
+  }
+
+  body[data-dsh-maid-atelier] div[data-sidebar-collapsed]
+    > :is([class*='centerCol'], [data-pane='conversation']) {
+    flex: 1 1 auto !important;
+    width: 100% !important;
+    min-height: 0 !important;
+  }
+
+  /* The dock: a fixed 48px target above the composer. The box itself stays
+     inert so it never eats a tap meant for the transcript behind it; only the
+     toggle inside it is interactive. */
+  body[data-dsh-maid-atelier] div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) {
+    position: fixed !important;
+    top: auto !important;
+    right: auto !important;
+    bottom: var(--maid-dock-offset, calc(env(safe-area-inset-bottom, 0px) + 84px)) !important;
+    left: 10px !important;
+    order: 0 !important;
+    box-sizing: border-box !important;
+    width: 48px !important;
+    min-width: 48px !important;
+    max-width: 48px !important;
+    height: 48px !important;
+    min-height: 48px !important;
+    max-height: 48px !important;
+    flex: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: none !important;
+    box-shadow: none !important;
+    overflow: visible !important;
+    pointer-events: none !important;
+    z-index: 40 !important;
+  }
+
+  /* One centred row inside the dock: the logo row and nothing else. Hiding
+     every sibling of `logoRow` keeps this independent of the host's row order
+     and of rows a later build may add. */
+  body[data-dsh-maid-atelier] div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    :is(div:has(> [class*='logoRow']), [class*='logoRow']) {
+    box-sizing: border-box !important;
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 0 !important;
+    width: 48px !important;
+    min-width: 0 !important;
+    height: 48px !important;
+    min-height: 48px !important;
+    max-height: 48px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    flex: none !important;
+    overflow: visible !important;
+    pointer-events: none !important;
+  }
+
+  body[data-dsh-maid-atelier] div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    div:has(> [class*='logoRow']) > :not([class*='logoRow']) {
+    display: none !important;
+  }
+
+  @supports not (selector(:has(*))) {
+    body[data-dsh-maid-atelier] div[data-sidebar-collapsed]
+      :is([data-pane='sidebar'], [class*='sidebarCol']) > div {
+      box-sizing: border-box !important;
+      display: flex !important;
+      flex-direction: row !important;
+      align-items: center !important;
+      justify-content: center !important;
+      width: 48px !important;
+      height: 48px !important;
+      min-height: 48px !important;
+      max-height: 48px !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      overflow: visible !important;
+      pointer-events: none !important;
+    }
+
+    body[data-dsh-maid-atelier] div[data-sidebar-collapsed]
+      :is([data-pane='sidebar'], [class*='sidebarCol'])
+      > div > :not([class*='logoRow']) {
+      display: none !important;
+    }
+  }
+
+  /* The toggle is the whole target and the only interactive thing left. The
+     rail variant already paints it as a gold-ringed navy medallion, so this
+     only sizes it and hands it the pointer. */
+  body[data-dsh-maid-atelier] div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    [class*='logoRow'] button[class*='toggle'] {
+    box-sizing: border-box !important;
+    width: 48px !important;
+    min-width: 48px !important;
+    height: 48px !important;
+    min-height: 48px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    place-items: center !important;
+    justify-content: center !important;
+    pointer-events: auto !important;
+    cursor: pointer !important;
+  }
+
+  /* Expanded: the column floats over the conversation instead of squeezing it. */
+  body[data-dsh-maid-atelier]
+    div:not([data-sidebar-collapsed]):has(> :is([data-pane='sidebar'], [class*='sidebarCol']))
+    :is([data-pane='sidebar'], [class*='sidebarCol']) {
+    position: fixed !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    width: min(300px, 84vw) !important;
+    height: 100dvh !important;
+    max-height: 100dvh !important;
+    z-index: 60 !important;
+    border-right: 0.5px solid var(--dsw-alias-border-l3) !important;
+    box-shadow: 24px 0 64px rgba(8, 17, 48, 0.35) !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain !important;
+  }
+
+  body[data-dsh-maid-atelier]
+    div:has(> :is([data-pane='sidebar'], [class*='sidebarCol'])) > [class*='handle'] {
+    display: none !important;
+  }
+
+  body[data-dsh-maid-atelier]
+    :is([data-pane='sidebar'], [class*='sidebarCol']):has([class*='regionArea']:not([style*='display: none'])) {
+    overscroll-behavior: contain !important;
+  }
+}
+
 /* Workspace groups receive skin-owned semantic hooks from the client entry.
    This keeps the ornamental tree independent from generated CSS-module names
    while leaving the official rows and their interactions intact. */

--- a/maid-atelier/src/client/mobile-dock.ts
+++ b/maid-atelier/src/client/mobile-dock.ts
@@ -1,0 +1,170 @@
+/**
+ * Phone dock geometry: keep the floating brand dock clear of the composer.
+ *
+ * The phone-chrome block in the stylesheet turns the collapsed sidebar column
+ * into a fixed 48px target at the bottom-left, sitting above the composer. CSS
+ * cannot express where the composer ends, and the distance changes when the
+ * composer grows past one line, when the shell swaps the hero for an active
+ * conversation, and when the software keyboard pins the shell to a shorter band
+ * — so this module measures the composer's top edge and publishes it as
+ * `--maid-dock-offset`, the `bottom` distance the dock consumes.
+ *
+ * The composer's *seat* is the observed element, not the card: the card keeps
+ * its size across the hero-to-conversation swap while the seat that holds it
+ * does not, and an observer beats a scroll listener that would force layout on
+ * every transcript scroll.
+ *
+ * The distance is measured from `innerHeight` because a fixed box resolves
+ * against the layout viewport: a fixed ancestor does not establish a containing
+ * block for a fixed descendant (only transform, filter, contain, will-change and
+ * container-type do), so the shell pinning itself to the keyboard does not move
+ * the dock's reference frame.
+ */
+
+/** `bottom` distance that keeps the phone dock above the composer. */
+const DOCK_PROPERTY = '--maid-dock-offset'
+/** The composer's seat; its size changes when the shell swaps hero for conversation. */
+const COMPOSER_SEAT_SELECTOR = '[data-composer-seat]'
+/** The seat's card: the composer while a prompt is being drafted. */
+const COMPOSER_CARD_SELECTOR = '[data-composer-card]'
+/** The takeover card that replaces the composer while a question or plan pends. */
+const TAKEOVER_CARD_SELECTOR = ":is([data-question-key], [data-plan-review-key]) > section"
+/** The host marks the conversation phase the skin already keys several rules off. */
+const PHASE_HERO_SELECTOR = "[data-phase='hero']"
+/** Phone widths own the dock; above them the host's own rail is in charge. */
+const PHONE_MAX_WIDTH = 700
+/** Breathing room between the dock's top edge and the composer's. */
+const DOCK_GAP = 10
+/** In the hero phase a 28px workspace chip row and its 8px gap sit above the input bar. */
+const HERO_STACK_CLEARANCE = 36
+/** Never let the dock sink into the home indicator area. */
+const DOCK_MIN_BOTTOM = 64
+/** Never let the dock ride over the top edge of the shell. */
+const DOCK_MIN_TOP = 10
+/** The dock's own edge length, mirrored from the stylesheet. */
+const DOCK_SIZE = 48
+/** The composer mounts with the shell; a few settle passes cover the rest. */
+const SETTLE_DELAYS = [250, 1000, 3000]
+
+/**
+ * Publish the `bottom` distance that keeps the phone dock above the composer.
+ * @param body - skin owning element (document.body); supplies the document and view.
+ * @returns disposer removing the observer, the listeners and the published variable.
+ */
+export function installMaidMobileDock(body: HTMLElement): () => void {
+  const doc = body.ownerDocument
+  const defaultView = doc.defaultView
+  if (defaultView === null) return () => {}
+  const view = defaultView
+  const root = doc.documentElement
+  const visual = view.visualViewport ?? null
+  const ResizeObserverCtor = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver
+  const raf = view.requestAnimationFrame?.bind(view)
+  const caf = view.cancelAnimationFrame?.bind(view)
+
+  let frame: number | null = null
+  let pending = false
+  let disposed = false
+  let written: string | null = null
+  let observed: Element | null = null
+  let seatObserver: ResizeObserver | null = null
+  const settleTimers: Array<ReturnType<typeof setTimeout>> = []
+
+  /** The card the dock must clear: the composer, or whatever took its seat over. */
+  const resolveAnchor = (): Element | null => doc.querySelector(COMPOSER_CARD_SELECTOR)
+    ?? doc.querySelector(TAKEOVER_CARD_SELECTOR)
+
+  function watchSeat(): void {
+    const next = doc.querySelector(COMPOSER_SEAT_SELECTOR) ?? resolveAnchor()
+    if (next === observed) return
+    observed = next
+    seatObserver?.disconnect()
+    if (next === null || ResizeObserverCtor === undefined) return
+    seatObserver ??= new ResizeObserverCtor(() => { schedule() })
+    seatObserver.observe(next)
+  }
+
+  const withdraw = (): void => {
+    if (written === null) return
+    root.style.removeProperty(DOCK_PROPERTY)
+    written = null
+  }
+
+  function update(): void {
+    if (disposed) return
+    watchSeat()
+    const anchor = resolveAnchor()
+    if (view.innerWidth > PHONE_MAX_WIDTH || anchor === null) {
+      withdraw()
+      return
+    }
+    const box = anchor.getBoundingClientRect()
+    if (box.width === 0) {
+      withdraw()
+      return
+    }
+    // The hero phase stacks its workspace chip row above the input bar, so the
+    // dock must clear that row too or it lands on the workspace picker.
+    const hero = anchor.closest(PHASE_HERO_SELECTOR) !== null
+    const clearance = DOCK_GAP + (hero ? HERO_STACK_CLEARANCE : 0)
+    const ceiling = Math.max(view.innerHeight - DOCK_MIN_TOP - DOCK_SIZE, DOCK_MIN_BOTTOM)
+    const distance = Math.min(
+      Math.max(view.innerHeight - box.top + clearance, DOCK_MIN_BOTTOM),
+      ceiling,
+    )
+    const next = `${Math.round(distance)}px`
+    if (next === written) return
+    root.style.setProperty(DOCK_PROPERTY, next)
+    written = next
+  }
+
+  function schedule(): void {
+    if (pending || disposed) return
+    pending = true
+    if (raf === undefined) {
+      pending = false
+      update()
+      return
+    }
+    frame = raf(() => {
+      frame = null
+      pending = false
+      update()
+    })
+  }
+
+  // The keyboard pins the shell, which moves the composer up with a shorter
+  // band; focus and typing catch the rest of the layout changes.
+  const onViewportChange = (): void => { schedule() }
+
+  view.addEventListener('resize', onViewportChange)
+  doc.addEventListener('focusin', onViewportChange, true)
+  doc.addEventListener('keydown', onViewportChange, true)
+  visual?.addEventListener('resize', onViewportChange)
+  visual?.addEventListener('scroll', onViewportChange)
+
+  schedule()
+  for (const delay of SETTLE_DELAYS) {
+    settleTimers.push(setTimeout(() => {
+      if (observed === null) schedule()
+    }, delay))
+  }
+
+  return () => {
+    disposed = true
+    if (frame !== null && caf !== undefined) caf(frame)
+    frame = null
+    pending = false
+    for (const timer of settleTimers) clearTimeout(timer)
+    settleTimers.length = 0
+    seatObserver?.disconnect()
+    seatObserver = null
+    observed = null
+    view.removeEventListener('resize', onViewportChange)
+    doc.removeEventListener('focusin', onViewportChange, true)
+    doc.removeEventListener('keydown', onViewportChange, true)
+    visual?.removeEventListener('resize', onViewportChange)
+    visual?.removeEventListener('scroll', onViewportChange)
+    withdraw()
+  }
+}

--- a/maid-atelier/tests/mobile-dock.spec.ts
+++ b/maid-atelier/tests/mobile-dock.spec.ts
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { installMaidMobileDock } from '../src/client/mobile-dock.ts'
+
+/** jsdom reports 1024x768 for every window. */
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: height })
+}
+
+function box(top: number, height = 140, left = 16, width = 358): DOMRect {
+  return {
+    x: left,
+    y: top,
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+/** jsdom ships no ResizeObserver either; keep the instances addressable. */
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+  readonly targets = new Set<Element>()
+
+  constructor(readonly callback: () => void) {
+    FakeResizeObserver.instances.push(this)
+  }
+
+  observe(target: Element): void { this.targets.add(target) }
+  unobserve(target: Element): void { this.targets.delete(target) }
+  disconnect(): void { this.targets.clear() }
+  fire(): void { this.callback() }
+}
+
+/** The composer's card, positioned where a phone would put it. */
+function mountComposerCard(top: number, height = 140): HTMLElement {
+  const card = document.createElement('div')
+  card.setAttribute('data-composer-card', '')
+  card.getBoundingClientRect = () => box(top, height)
+  document.body.append(card)
+  return card
+}
+
+function varOf(name: string): string {
+  return document.documentElement.style.getPropertyValue(name)
+}
+
+/** Let a queued animation frame and the settle timers run. */
+function flush(ms = 60): Promise<void> {
+  return new Promise(resolve => { setTimeout(resolve, ms) })
+}
+
+let disposers: Array<() => void> = []
+
+function install(): () => void {
+  const dispose = installMaidMobileDock(document.body)
+  disposers.push(dispose)
+  return dispose
+}
+
+beforeEach(() => {
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+  disposers = []
+  FakeResizeObserver.instances = []
+  Object.defineProperty(globalThis, 'ResizeObserver', { configurable: true, value: FakeResizeObserver })
+  setViewport(390, 844)
+})
+
+afterEach(() => {
+  for (const dispose of disposers) dispose()
+  disposers = []
+  Reflect.deleteProperty(globalThis, 'ResizeObserver')
+  document.documentElement.removeAttribute('style')
+})
+
+describe('Maid Atelier phone dock geometry', () => {
+  it('publishes the composer top edge as a bottom distance', async () => {
+    mountComposerCard(438)
+    install()
+    await flush()
+
+    // 844 (layout viewport) - 438 (composer top) + 10 (gap)
+    expect(varOf('--maid-dock-offset')).toBe('416px')
+  })
+
+  it('follows a composer that grows past one line', async () => {
+    const card = mountComposerCard(438)
+    install()
+    await flush()
+
+    card.getBoundingClientRect = () => box(380, 198)
+    window.dispatchEvent(new Event('resize'))
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).toBe('474px')
+  })
+
+  it('clears the distance when the composer is gone', async () => {
+    const card = mountComposerCard(438)
+    install()
+    await flush()
+    expect(varOf('--maid-dock-offset')).toBe('416px')
+
+    card.remove()
+    window.dispatchEvent(new Event('resize'))
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).toBe('')
+  })
+
+  it('falls back to the takeover card when a question replaces the composer', async () => {
+    const frame = document.createElement('div')
+    frame.setAttribute('data-question-key', 'k')
+    const card = document.createElement('section')
+    card.getBoundingClientRect = () => box(400, 300, 36, 318)
+    frame.append(card)
+    document.body.append(frame)
+    install()
+    await flush()
+
+    // 844 - 400 + 10
+    expect(varOf('--maid-dock-offset')).toBe('454px')
+  })
+
+  it('clears the hero phase workspace chip row above the input bar', async () => {
+    const phase = document.createElement('div')
+    phase.setAttribute('data-phase', 'hero')
+    const card = document.createElement('div')
+    card.setAttribute('data-composer-card', '')
+    card.getBoundingClientRect = () => box(438)
+    phase.append(card)
+    document.body.append(phase)
+    install()
+    await flush()
+
+    // 844 - 438 + 10 (gap) + 36 (28px chip row + its 8px gap)
+    expect(varOf('--maid-dock-offset')).toBe('452px')
+  })
+
+  it('measures against the layout viewport, not a pinning shell', async () => {
+    // A fixed box resolves against the layout viewport unless an ancestor
+    // transforms it, so the keyboard's shorter visual viewport must not shift
+    // the dock's `bottom`.
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: { height: 404, offsetTop: 12, scale: 1, width: 390, addEventListener: () => {}, removeEventListener: () => {} },
+    })
+    mountComposerCard(300)
+    install()
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).toBe('554px')
+  })
+
+  it('watches the composer seat so a hero-to-conversation swap re-measures', async () => {
+    const seat = document.createElement('div')
+    seat.setAttribute('data-composer-seat', '')
+    const card = mountComposerCard(438)
+    seat.append(card)
+    document.body.append(seat)
+    install()
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).toBe('416px')
+    const observer = FakeResizeObserver.instances.at(-1)
+    expect(observer?.targets.has(seat)).toBe(true)
+
+    // The shell swaps hero for an active conversation: the card moves to the
+    // foot of the column while keeping its size, so only the seat reports it.
+    card.getBoundingClientRect = () => box(660)
+    observer?.fire()
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).toBe('194px')
+  })
+
+  it('leaves the desktop viewport without a dock distance', async () => {
+    setViewport(1280, 900)
+    mountComposerCard(720)
+    install()
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).toBe('')
+  })
+
+  it('gives back the variable, the observer and the listeners on dispose', async () => {
+    const seat = document.createElement('div')
+    seat.setAttribute('data-composer-seat', '')
+    const card = mountComposerCard(438)
+    seat.append(card)
+    document.body.append(seat)
+    const dispose = install()
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).not.toBe('')
+    dispose()
+
+    expect(varOf('--maid-dock-offset')).toBe('')
+    expect(FakeResizeObserver.instances.at(-1)?.targets.size).toBe(0)
+  })
+
+  it('stops measuring once disposed', async () => {
+    const card = mountComposerCard(438)
+    const dispose = install()
+    await flush()
+    dispose()
+
+    card.getBoundingClientRect = () => box(200)
+    window.dispatchEvent(new Event('resize'))
+    await flush()
+
+    expect(varOf('--maid-dock-offset')).toBe('')
+  })
+})


### PR DESCRIPTION
# feat(mobile): float the collapsed rail above the composer on phones — **proposal, not a fix**

Branch: **`feat/mobile-topbar`** (1 commit on top of `origin/main` @ `daa6c69`) · +568/−0 · 4 files
Base: `Small-tailqwq/dsh-deep-whale` → `maid-atelier/`

> **Correction to the previous revision of this description.** It said the top
> bar had been replaced "following reviewer feedback". There was no such
> feedback and no discussion on this PR to link to — that wording was wrong, and
> the direction change was my own decision after the first push. I am sorry for
> sending you looking for a thread that does not exist. The rest of this
> description is the reasoning that actually produced the change.
>
> The branch name is also stale: it was `feat/mobile-topbar` for the withdrawn
> top-bar proposal. A pull request's head branch cannot be renamed without
> closing it, so the name stays and this description carries the correction.

**This PR is now the navigation proposal only.** The two phone defect fixes it
used to carry are their own PR, **#124** — based on `main`, containing no dock
CSS, no dock module and no dock test, so the fixes can be reviewed and merged
without this design being accepted.

| file | what it adds |
|---|---|
| `src/client/maid-atelier.module.css` | the phone-chrome block: dock + overlay drawer |
| `src/client/mobile-dock.ts` | publishes the composer's measured top edge as `--maid-dock-offset` |
| `src/client/index.ts` | two lines wiring the module |
| `tests/mobile-dock.spec.ts` | 10 jsdom tests for the offset rules |

## What it proposes

The host pins its collapsed rail to the left edge as a 56px column. At 390x844
that is 334px of conversation width, 14% of the viewport spent on a strip whose
only always-useful control is the toggle that opens the column. Under 700px
portrait this proposal takes that column out of the layout: the conversation owns
the whole viewport and the toggle — drawn as the product's own brand mark —
floats above the composer's top-left corner. New Session, the panel buttons and
Settings stay one tap away in the drawer the dock opens.

| measured at 390x844 | before | after |
|---|---|---|
| sidebar | 56x844 column | 48x48 dock at (10, 344) |
| conversation column | 334px | **390px** (+17%) |
| drawer (expanded column) | squeezes the column | 301x844 overlay, conversation column unchanged |
| dock / composer gap | — | 10px above the composer top |
| layout spill / console errors | 0 / 0 | 0 / 0 |

Implementation notes for review:

- Hooks are the host's own: `data-sidebar-collapsed` on the AppFrame,
  `sidebarCol`, and the `logoRow` / `toggle` names the rest of the stylesheet
  already matches on, with a `@supports not (selector(:has(*)))` arm. Everything
  the expanded column already offers is hidden by matching *siblings of
  `logoRow`* rather than a list of class names, so a later build cannot
  re-introduce a row into the dock.
- The dock is the collapsed column itself, not a new control, so it carries the
  host's own toggle semantics and `aria-expanded` state. `z-index: 40` is inside
  the host's layer contract (menu 100 / modal 1000).
- `--maid-dock-offset` is the composer's measured top edge plus the 36px the hero
  phase spends on its workspace chip row, so the dock clears the workspace picker
  rather than landing on it. The composer's *seat* is the `ResizeObserver` target
  because the card keeps its size across the hero-to-conversation swap.
- Landscape keeps the rail: there the scarce axis is height, so 56px of width is
  the cheaper trade (verified at 844x390).

## Open points — I am not implementing further navigation work until these are agreed

Raised in review, and all three are fair:

1. **Repositioning.** The dock follows the composer vertically and its horizontal
   position is fixed at the left edge; there is no drag and no stored position.
   That was the least code that worked, not a product decision. If the dock
   direction is viable I would add a corner choice (bottom-left / bottom-right)
   as a customization value and make the dock draggable with the position stored
   through the skin-manager settings. I have not built it because I do not want
   to guess the interaction model unilaterally.
2. **Other modes.** After the earlier push the dock is the *only* phone-portrait
   mode; there is no way back to the rail or the top bar. That is a real
   regression for anyone who used the bar's directly visible actions — New
   Session, the panels and Settings each cost one extra tap now. The three
   layouts can all be values of the existing skin customization, and I am happy
   to implement whichever subset you want selectable.
3. **Scope.** #124 now carries the defect fixes independently, as asked.

**No further navigation commits from me until we agree on the model.** If the
persistent rail is the better answer, this PR can be dropped — #124 does not
depend on it.

## Build output

`lib/` is not included, same as #119/#120: `npm run build` cannot run outside the
scaffolding checkout (`src/client/customization.ts` resolves
`../../../skin-manager/src/protocol.ts`, and the build script calls
`../scripts/write-skin-build.mjs`).
