### PR TITLE
fix(mobile): five phone defects — prompt card, software keyboard, drawer dismissal, model picker, settings hand-off

### DIFF
--- a/maid-atelier/src/client/index.ts
+++ b/maid-atelier/src/client/index.ts
@@ -44,6 +44,7 @@ import { installMaidComposerCapsule } from './composer-capsule.ts'
 import { installMaidComposerDismiss } from './composer-dismiss.ts'
 import { installMaidComposerScroll } from './composer-scroll.ts'
 import { installMaidMobileDrawerAutoClose } from './mobile-drawer.ts'
+import { installMaidMobileViewport } from './mobile-viewport.ts'
 import { createMaidSettingsNavigation } from './settings-navigation.ts'
 import { installMaidCustomization } from './customization.ts'
 import { installMaidBootError } from './boot-error.ts'
@@ -556,6 +557,7 @@ export function apply(ctx: Context): void {
   const settingsNavigation = createMaidSettingsNavigation(body)
   ctx.effect(() => settingsNavigation.dispose, 'ui-skin-maid-atelier: settings navigation hint')
   ctx.effect(() => installMaidMobileDrawerAutoClose(body), 'ui-skin-maid-atelier: mobile drawer auto-close')
+  ctx.effect(() => installMaidMobileViewport(body), 'ui-skin-maid-atelier: phone viewport')
   disposeMaidTableCards = installMaidTableCards(ctx).dispose
   body.style.setProperty('--maid-top-trim-art', `url(${MAID_ATELIER_TOP_TRIM_TILE})`)
   body.style.setProperty('--maid-boot-error-left-art', `url(${MAID_BOOT_ERROR_LEFT})`)

--- a/maid-atelier/src/client/maid-atelier.module.css
+++ b/maid-atelier/src/client/maid-atelier.module.css
@@ -1567,6 +1567,26 @@ body[data-dsh-maid-atelier][data-maid-sidebar-size='rail']
   }
 }
 
+/* The software keyboard does not resize the layout viewport, and this shell is
+   `height: 100%` of it, so a focused composer stays behind the keyboard and the
+   height-locked page cannot scroll it into view. While the keyboard is up the
+   client entry pins the application root to the band VisualViewport reports;
+   on engines that honour the `interactive-widget=resizes-content` viewport hint
+   the layout viewport resizes on its own and this block never engages. */
+@media (pointer: coarse) {
+  html[data-maid-keyboard='open'] body[data-dsh-maid-atelier] [id='root'] {
+    position: fixed !important;
+    top: var(--maid-vv-top, 0px) !important;
+    right: 0 !important;
+    bottom: auto !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: var(--maid-vv-height, 100dvh) !important;
+    max-height: none !important;
+    overscroll-behavior: none !important;
+  }
+}
+
 /* Workspace groups receive skin-owned semantic hooks from the client entry.
    This keeps the ornamental tree independent from generated CSS-module names
    while leaving the official rows and their interactions intact. */

--- a/maid-atelier/src/client/maid-atelier.module.css
+++ b/maid-atelier/src/client/maid-atelier.module.css
@@ -3046,6 +3046,32 @@ body[data-dsh-maid-atelier] [data-composer-card]
   }
 }
 
+/* The host drops the model name in a narrow composer — its own stylesheet hides
+   the label and shows the icon inside `@container (width<=360px)`. The phone
+   rules above still stretch the picker across the whole seat, so with the name
+   gone the chip keeps a text-sized box and its icon is stranded at the left of
+   it. Once the name is hidden the picker is an icon chip: let it size to its
+   content, and hold it against send on the trailing edge. */
+@container (width<=360px) {
+  body[data-dsh-maid-atelier] :is([data-phase='hero'], [data-phase='active'])
+    [data-composer-card] [data-slot='conversation.input.model'] > [class$='_root'] {
+    flex: 0 1 auto;
+  }
+
+  body[data-dsh-maid-atelier] :is([data-phase='hero'], [data-phase='active'])
+    [data-composer-card] [data-slot='conversation.input.model'] > [class$='_root']
+    > button[aria-haspopup='menu'] {
+    width: auto;
+    max-width: 100%;
+    padding: 0 4px 0 8px;
+  }
+
+  body[data-dsh-maid-atelier] :is([data-phase='hero'], [data-phase='active'])
+    [data-composer-card] > [class*='row'] > [class*='trailing'] {
+    justify-content: flex-end;
+  }
+}
+
 /* Conversation surfaces stay transparent so the character backdrop shows
    through (including the new-session workspace); only message-carrying
    surfaces (bubbles, think blocks) get a translucent porcelain base. */

--- a/maid-atelier/src/client/maid-atelier.module.css
+++ b/maid-atelier/src/client/maid-atelier.module.css
@@ -1500,6 +1500,73 @@ body[data-dsh-maid-atelier][data-maid-sidebar-size='rail']
   box-shadow: none;
 }
 
+/* The window prompt (ask_user_question) and the plan review take the composer
+   seat over. Their desktop footer is one non-wrapping row — pager, status text
+   and the two action buttons — which measures 349px inside a 318px card on a
+   390px phone: the primary button is pushed past the card's right edge and
+   clipped by its own `overflow: hidden`, and at 360px its centre falls outside
+   the card so the tap misses it entirely. Reflow the footer, give the actions a
+   full-width row of touch-sized buttons, and cap the card against the visual
+   viewport rather than the layout viewport the keyboard does not shrink. */
+@media (max-width: 700px) {
+  body[data-dsh-maid-atelier] :is([data-question-key], [data-plan-review-key]) {
+    padding: 6px 10px 10px !important;
+  }
+
+  body[data-dsh-maid-atelier]
+    :is([data-question-key], [data-plan-review-key]) > section {
+    max-height: min(calc(var(--maid-vv-height, 100dvh) - 96px), 520px) !important;
+  }
+
+  body[data-dsh-maid-atelier]
+    :is([data-question-key], [data-plan-review-key]) > section
+    > :is(footer, div:last-child) {
+    flex-wrap: wrap !important;
+    align-items: center !important;
+    gap: 8px !important;
+    padding: 0 10px !important;
+  }
+
+  /* Actions own the last row; the pager and the status text share the one above. */
+  body[data-dsh-maid-atelier]
+    :is([data-question-key], [data-plan-review-key]) > section
+    > :is(footer, div:last-child) > :last-child {
+    flex: 1 1 100% !important;
+    flex-wrap: wrap !important;
+    justify-content: stretch !important;
+    gap: 8px !important;
+  }
+
+  body[data-dsh-maid-atelier]
+    :is([data-question-key], [data-plan-review-key]) > section
+    > :is(footer, div:last-child) > :last-child > button {
+    flex: 1 1 0 !important;
+    min-height: 44px !important;
+  }
+
+  /* Icon-only affordances (collapse, dismiss, previous, next) meet the touch
+     minimum; the option rows grow with them. */
+  body[data-dsh-maid-atelier]
+    :is([data-question-key], [data-plan-review-key]) button[aria-label] {
+    min-width: 36px !important;
+    min-height: 36px !important;
+  }
+
+  body[data-dsh-maid-atelier]
+    :is([data-question-key], [data-plan-review-key])
+    :is([role='radio'], [role='checkbox']) {
+    min-height: 44px !important;
+  }
+
+  @media (pointer: coarse) {
+    body[data-dsh-maid-atelier]
+      :is([data-question-key], [data-plan-review-key]) button[aria-label] {
+      min-width: 44px !important;
+      min-height: 44px !important;
+    }
+  }
+}
+
 /* Workspace groups receive skin-owned semantic hooks from the client entry.
    This keeps the ornamental tree independent from generated CSS-module names
    while leaving the official rows and their interactions intact. */

--- a/maid-atelier/src/client/mobile-drawer.ts
+++ b/maid-atelier/src/client/mobile-drawer.ts
@@ -1,9 +1,20 @@
 /**
  * `@deepseek-ai/dsh-client-ui-layout` closes its narrow sidebar only from the
- * toggle button — picking a session calls `openSession`, which never touches
- * `narrowExpanded`. On a phone the drawer therefore keeps covering the
- * conversation after a session switch, and the user has to close it by hand.
- * Mirror the toggle once the row click has been dispatched.
+ * toggle button. Two gestures a phone user expects are therefore missing:
+ *
+ * 1. picking a session calls `openSession`, which never touches
+ *    `narrowExpanded`, so the drawer keeps covering the conversation after a
+ *    session switch and has to be closed by hand;
+ * 2. tapping outside the open drawer does nothing at all — the host's
+ *    `overlayLayer` is only an overlay container (`pointer-events: none`, no
+ *    handler), not a scrim, so the drawer stays up until the toggle is found
+ *    again.
+ *
+ * Both are mirrored here: a row activation closes the overlay on the next frame,
+ * and a pointer that lands outside the open column dismisses it. The tap that
+ * dismisses is then swallowed, because on a phone the control behind the drawer
+ * is usually the composer — and its send button sits exactly in the corner a
+ * reader aims at when dismissing.
  *
  * The breakpoint mirrors `SIDEBAR_AUTO_COLLAPSE` in the layout package: below it
  * the collapsed column is a rail and the expanded column is an overlay, above it
@@ -13,18 +24,32 @@ const DRAWER_AUTO_COLLAPSE = 1024
 const SIDEBAR_COLUMN_SELECTOR = ":is([data-pane='sidebar'], [class*='sidebarCol'])"
 const SESSION_ROW_SELECTOR = '[data-maid-session-row], [role="treeitem"][class*="sessionRow"]'
 const ROW_AFFORDANCE_SELECTOR = '[role="menu"], [role="dialog"], input, textarea, [aria-haspopup]'
+/** Popups own the tap that dismisses them, so the drawer waits its turn. */
+const OPEN_POPUP_SELECTOR = [
+  '[role="menu"]',
+  '[role="listbox"]',
+  '[role="dialog"]',
+  '[aria-modal="true"]',
+  '[data-radix-popper-content-wrapper]',
+  '[data-floating-ui-portal]',
+].join(',')
+/** The host's resize handle is a drag, not a dismissal. */
+const DRAG_HANDLE_SELECTOR = "[class*='handle']"
+/** How long a dismissing pointer keeps swallowing the click it produced. */
+const SWALLOW_WINDOW_MS = 400
 
 /**
- * Close the narrow sidebar after a session row (or the sidebar's New Session
- * button) was activated.
+ * Close the narrow sidebar when a session row (or the sidebar's New Session
+ * button) is activated, and when a tap lands outside the open drawer.
  * @param body - skin owning element (document.body); supplies the document and view.
- * @returns disposer removing the click listener installed here.
+ * @returns disposer removing the listeners installed here.
  */
 export function installMaidMobileDrawerAutoClose(body: HTMLElement): () => void {
   const doc = body.ownerDocument
   const view = doc.defaultView
   if (view === null) return () => {}
   let pendingFrame: number | null = null
+  let swallowTimer: ReturnType<typeof setTimeout> | null = null
 
   const drawerOpen = (): boolean => view.innerWidth < DRAWER_AUTO_COLLAPSE
     && doc.querySelector('div[data-sidebar-collapsed]') === null
@@ -37,9 +62,61 @@ export function installMaidMobileDrawerAutoClose(body: HTMLElement): () => void 
       ?.click()
   }
 
+  /** Gestures that keep the drawer open: its own chrome, a popup, a drag handle. */
+  const ownsGesture = (target: Element): boolean => target.closest(SIDEBAR_COLUMN_SELECTOR) !== null
+    || target.closest(ROW_AFFORDANCE_SELECTOR) !== null
+    || target.closest(DRAG_HANDLE_SELECTOR) !== null
+    || doc.querySelector(OPEN_POPUP_SELECTOR) !== null
+
+  /** Dismiss the drawer for a gesture outside it; true when it was open to close. */
+  const dismissOutside = (target: Element): boolean => {
+    if (!drawerOpen() || ownsGesture(target)) return false
+    closeDrawer()
+    return true
+  }
+
+  const armSwallow = (): void => {
+    if (swallowTimer !== null) clearTimeout(swallowTimer)
+    swallowTimer = setTimeout(() => { swallowTimer = null }, SWALLOW_WINDOW_MS)
+  }
+
+  const releaseSwallow = (): boolean => {
+    if (swallowTimer === null) return false
+    clearTimeout(swallowTimer)
+    swallowTimer = null
+    return true
+  }
+
+  const onPointerDown = (event: PointerEvent): void => {
+    // Secondary buttons and extra touches during a pinch are not dismissals.
+    if (event.isPrimary === false || event.button > 0) return
+    const target = event.target
+    if (!(target instanceof Element) || !dismissOutside(target)) return
+    armSwallow()
+  }
+
+  const onMouseDown = (event: MouseEvent): void => {
+    // Cancelling the default focus keeps a dismissing tap from raising the phone
+    // keyboard on the composer behind the drawer.
+    if (swallowTimer !== null) event.preventDefault()
+  }
+
   const onClick = (event: MouseEvent): void => {
     const target = event.target
     if (!(target instanceof Element)) return
+
+    // The pointerdown that dismissed the drawer already did the work: swallow the
+    // click it produced so it cannot activate the control behind the overlay.
+    if (releaseSwallow()) {
+      event.preventDefault()
+      event.stopPropagation()
+      return
+    }
+
+    // Synthetic clicks (no pointerdown) still dismiss; for a real pointer the
+    // drawer is already closed by now, so this is a no-op.
+    if (drawerOpen() && dismissOutside(target)) return
+
     // Row-internal affordances (overflow menu, inline rename, popovers) own the
     // gesture and keep the drawer open.
     if (target.closest(ROW_AFFORDANCE_SELECTOR) !== null) return
@@ -59,10 +136,15 @@ export function installMaidMobileDrawerAutoClose(body: HTMLElement): () => void 
     })
   }
 
+  doc.addEventListener('pointerdown', onPointerDown, true)
+  doc.addEventListener('mousedown', onMouseDown, true)
   doc.addEventListener('click', onClick, true)
   return () => {
+    doc.removeEventListener('pointerdown', onPointerDown, true)
+    doc.removeEventListener('mousedown', onMouseDown, true)
     doc.removeEventListener('click', onClick, true)
     if (pendingFrame !== null) view.cancelAnimationFrame(pendingFrame)
     pendingFrame = null
+    releaseSwallow()
   }
 }

--- a/maid-atelier/src/client/mobile-drawer.ts
+++ b/maid-atelier/src/client/mobile-drawer.ts
@@ -1,6 +1,6 @@
 /**
  * `@deepseek-ai/dsh-client-ui-layout` closes its narrow sidebar only from the
- * toggle button. Two gestures a phone user expects are therefore missing:
+ * toggle button. Three gestures a phone user expects are therefore missing:
  *
  * 1. picking a session calls `openSession`, which never touches
  *    `narrowExpanded`, so the drawer keeps covering the conversation after a
@@ -8,13 +8,18 @@
  * 2. tapping outside the open drawer does nothing at all — the host's
  *    `overlayLayer` is only an overlay container (`pointer-events: none`, no
  *    handler), not a scrim, so the drawer stays up until the toggle is found
- *    again.
+ *    again;
+ * 3. the drawer's own settings entry opens a host dialog *above* the overlay,
+ *    and closing that dialog drops the reader back onto the drawer — which, at
+ *    phone widths, covers the composer. Tapping the prompt then lands on a
+ *    session row and nothing can be typed.
  *
- * Both are mirrored here: a row activation closes the overlay on the next frame,
- * and a pointer that lands outside the open column dismisses it. The tap that
- * dismisses is then swallowed, because on a phone the control behind the drawer
- * is usually the composer — and its send button sits exactly in the corner a
- * reader aims at when dismissing.
+ * All three are mirrored here: a row activation closes the overlay on the next
+ * frame, a pointer that lands outside the open column dismisses it, and the
+ * settings dialog is watched so that dismissing it takes the overlay with it.
+ * The tap that dismisses is then swallowed, because on a phone the control
+ * behind the drawer is usually the composer — and its send button sits exactly
+ * in the corner a reader aims at when dismissing.
  *
  * The breakpoint mirrors `SIDEBAR_AUTO_COLLAPSE` in the layout package: below it
  * the collapsed column is a rail and the expanded column is an overlay, above it
@@ -35,8 +40,18 @@ const OPEN_POPUP_SELECTOR = [
 ].join(',')
 /** The host's resize handle is a drag, not a dismissal. */
 const DRAG_HANDLE_SELECTOR = "[class*='handle']"
+/** The drawer's own settings entry; its dialog is the one that strands the reader. */
+const SETTINGS_TRIGGER_SELECTOR = "[data-slot='sidebar.settings'] button[aria-haspopup='dialog']"
+/** Only a dialog panel counts as the settings surface the reader opened. */
+const DIALOG_SELECTOR = '[role="dialog"]'
 /** How long a dismissing pointer keeps swallowing the click it produced. */
 const SWALLOW_WINDOW_MS = 400
+/**
+ * How long to wait for the settings dialog to show up before giving up on the
+ * watch. A trigger whose dialog never opens must not leave an observer on every
+ * body mutation for the rest of the session.
+ */
+const DIALOG_WATCH_TIMEOUT_MS = 4000
 
 /**
  * Close the narrow sidebar when a session row (or the sidebar's New Session
@@ -85,6 +100,51 @@ export function installMaidMobileDrawerAutoClose(body: HTMLElement): () => void 
     clearTimeout(swallowTimer)
     swallowTimer = null
     return true
+  }
+
+  /**
+   * Watch the settings dialog the drawer just opened, and take the overlay down
+   * with it. The watcher only starts counting once the dialog has actually been
+   * on screen, so the gap between the click and the host mounting it cannot be
+   * mistaken for a dismissal.
+   */
+  let dialogWatch: MutationObserver | null = null
+  let dialogWatchTimer: ReturnType<typeof setTimeout> | null = null
+
+  const stopDialogWatch = (): void => {
+    dialogWatch?.disconnect()
+    dialogWatch = null
+    if (dialogWatchTimer !== null) {
+      clearTimeout(dialogWatchTimer)
+      dialogWatchTimer = null
+    }
+  }
+
+  const watchSettingsDialog = (): void => {
+    if (dialogWatch !== null) return
+    let seen = false
+    const check = (): void => {
+      if (doc.querySelector(DIALOG_SELECTOR) !== null) {
+        seen = true
+        if (dialogWatchTimer !== null) {
+          clearTimeout(dialogWatchTimer)
+          dialogWatchTimer = null
+        }
+        return
+      }
+      if (!seen) return
+      stopDialogWatch()
+      closeDrawer()
+    }
+    dialogWatch = new MutationObserver(check)
+    dialogWatch.observe(doc.body, { childList: true, subtree: true })
+    dialogWatchTimer = setTimeout(stopDialogWatch, DIALOG_WATCH_TIMEOUT_MS)
+  }
+
+  const onSettingsEntry = (event: MouseEvent): void => {
+    const target = event.target
+    if (!(target instanceof Element) || target.closest(SETTINGS_TRIGGER_SELECTOR) === null) return
+    watchSettingsDialog()
   }
 
   const onPointerDown = (event: PointerEvent): void => {
@@ -138,13 +198,16 @@ export function installMaidMobileDrawerAutoClose(body: HTMLElement): () => void 
 
   doc.addEventListener('pointerdown', onPointerDown, true)
   doc.addEventListener('mousedown', onMouseDown, true)
+  doc.addEventListener('click', onSettingsEntry, true)
   doc.addEventListener('click', onClick, true)
   return () => {
     doc.removeEventListener('pointerdown', onPointerDown, true)
     doc.removeEventListener('mousedown', onMouseDown, true)
+    doc.removeEventListener('click', onSettingsEntry, true)
     doc.removeEventListener('click', onClick, true)
     if (pendingFrame !== null) view.cancelAnimationFrame(pendingFrame)
     pendingFrame = null
     releaseSwallow()
+    stopDialogWatch()
   }
 }

--- a/maid-atelier/src/client/mobile-viewport.ts
+++ b/maid-atelier/src/client/mobile-viewport.ts
@@ -1,0 +1,182 @@
+/**
+ * Phone viewport: keep the host shell and the composer inside the band the
+ * software keyboard leaves visible.
+ *
+ * `html`, `body` and `#root` are height-locked to the layout viewport, and the
+ * layout viewport does not shrink for the software keyboard — iOS never does,
+ * Android only when the page opts in through the `interactive-widget` viewport
+ * hint. A focused composer therefore stays behind the keyboard, and the
+ * height-locked page has no scroll range to bring it back.
+ *
+ * This module appends that hint where the engine accepts it and, when the
+ * keyboard still shrinks only the visual viewport, publishes `--maid-vv-height`
+ * and `--maid-vv-top` and marks the root so the stylesheet can pin the
+ * application to the band `VisualViewport` reports. It also brings the composer
+ * back into the band once per keyboard opening, which is what a landscape phone
+ * needs: the hero stack is centred and taller than the band, so the composer
+ * would otherwise sit below the fold.
+ *
+ * Every write is idempotent and remembered, so a viewport that stops changing
+ * stops writing; the disposer removes the listeners, the published variables and
+ * the viewport hint the module appended — and nothing else.
+ */
+
+/** Root attribute that tells the stylesheet the shell is pinned to the keyboard. */
+const KEYBOARD_ATTRIBUTE = 'data-maid-keyboard'
+/** The visual viewport's height, published for the shell and the takeover cards. */
+const HEIGHT_PROPERTY = '--maid-vv-height'
+/** The visual viewport's offset from the layout viewport's top edge. */
+const TOP_PROPERTY = '--maid-vv-top'
+/** The seat's card: the composer while a prompt is being drafted. */
+const COMPOSER_CARD_SELECTOR = '[data-composer-card]'
+/** The takeover card that replaces the composer while a question or plan pends. */
+const TAKEOVER_CARD_SELECTOR = ":is([data-question-key], [data-plan-review-key]) > section"
+/** Phone widths own the bar-less layout; above them the host's own rail is in charge. */
+const PHONE_MAX_WIDTH = 700
+/** A touch pointer owns the keyboard shell even in landscape, where the shell is wide. */
+const COARSE_QUERY = '(pointer: coarse)'
+/** A visual viewport this much shorter than the layout viewport is a keyboard. */
+const KEYBOARD_MIN_GAP = 120
+/** The composer mounts with the shell; a few settle passes cover the rest. */
+const SETTLE_DELAYS = [250, 1000, 3000]
+
+/**
+ * Keep the phone shell inside the visual viewport while the software keyboard is
+ * open.
+ * @param body - skin owning element (document.body); supplies the document and view.
+ * @returns disposer restoring the meta hint and removing every listener and variable.
+ */
+export function installMaidMobileViewport(body: HTMLElement): () => void {
+  const doc = body.ownerDocument
+  const defaultView = doc.defaultView
+  if (defaultView === null) return () => {}
+  // Bound to its own const: TypeScript cannot keep the null-check narrowing of a
+  // captured variable inside the hoisted update/schedule closures below.
+  const view = defaultView
+  const root = doc.documentElement
+  const visual = view.visualViewport ?? null
+
+  // The host owns the viewport tag; only the appended hint is ours to remove.
+  const meta = doc.querySelector<HTMLMetaElement>("meta[name='viewport']")
+  const originalContent = meta?.getAttribute('content') ?? null
+  const hinted = meta !== null
+    && originalContent !== null
+    && !originalContent.includes('interactive-widget')
+  if (meta !== null && hinted) {
+    meta.setAttribute('content', `${originalContent}, interactive-widget=resizes-content`)
+  }
+
+  const raf = view.requestAnimationFrame?.bind(view)
+  const caf = view.cancelAnimationFrame?.bind(view)
+
+  let frame: number | null = null
+  let nudgeFrame: number | null = null
+  let pending = false
+  let disposed = false
+  let heightWritten: string | null = null
+  let topWritten: string | null = null
+  let keyboardMarked = false
+  const settleTimers: Array<ReturnType<typeof setTimeout>> = []
+
+  /** The card whose top the band must contain: the composer, or its takeover. */
+  const resolveAnchor = (): Element | null => doc.querySelector(COMPOSER_CARD_SELECTOR)
+    ?? doc.querySelector(TAKEOVER_CARD_SELECTOR)
+
+  const publish = (property: string, value: string, previous: string | null): string | null => {
+    if (value === previous) return previous
+    root.style.setProperty(property, value)
+    return value
+  }
+
+  function update(): void {
+    if (disposed) return
+    const phone = view.innerWidth <= PHONE_MAX_WIDTH
+    // A landscape phone is wider than the phone breakpoint, so the keyboard
+    // shell keys off the pointer as well as the width.
+    const coarse = view.matchMedia?.(COARSE_QUERY)?.matches ?? false
+    // A pinch-zoom keeps the layout viewport semantics the host shipped; only a
+    // genuine keyboard gap pins the shell to the visual viewport.
+    const unscaled = visual === null || Math.abs(visual.scale - 1) <= 0.01
+    const height = visual !== null && unscaled ? visual.height : view.innerHeight
+    const offset = visual !== null && unscaled ? visual.offsetTop : 0
+    const keyboard = (coarse || phone)
+      && visual !== null
+      && unscaled
+      && view.innerHeight - visual.height > KEYBOARD_MIN_GAP
+    const opened = keyboard && !keyboardMarked
+
+    heightWritten = publish(HEIGHT_PROPERTY, `${Math.round(height)}px`, heightWritten)
+    topWritten = publish(TOP_PROPERTY, `${Math.round(offset)}px`, topWritten)
+
+    if (keyboard !== keyboardMarked) {
+      keyboardMarked = keyboard
+      if (keyboard) root.setAttribute(KEYBOARD_ATTRIBUTE, 'open')
+      else root.removeAttribute(KEYBOARD_ATTRIBUTE)
+    }
+
+    // Reading after the attribute write flushes the pinned layout, so the card
+    // is measured where the reader will actually see it.
+    const anchor = resolveAnchor()
+    const box = anchor?.getBoundingClientRect()
+    if (!opened || anchor === null || box === undefined || box.bottom <= offset + height + 1) return
+
+    // The hero stack is centred and taller than a landscape band, so it would
+    // leave the composer below the fold. Bring it back once per keyboard opening
+    // rather than fighting the host on every frame.
+    const nudge = (): void => {
+      nudgeFrame = null
+      if (!disposed) anchor.scrollIntoView?.({ block: 'end', inline: 'nearest' })
+    }
+    if (raf === undefined) nudge()
+    else nudgeFrame = raf(nudge)
+  }
+
+  function schedule(): void {
+    if (pending || disposed) return
+    pending = true
+    if (raf === undefined) {
+      pending = false
+      update()
+      return
+    }
+    frame = raf(() => {
+      frame = null
+      pending = false
+      update()
+    })
+  }
+
+  const onViewportChange = (): void => { schedule() }
+
+  view.addEventListener('resize', onViewportChange)
+  doc.addEventListener('focusin', onViewportChange, true)
+  visual?.addEventListener('resize', onViewportChange)
+  visual?.addEventListener('scroll', onViewportChange)
+
+  schedule()
+  for (const delay of SETTLE_DELAYS) {
+    settleTimers.push(setTimeout(() => { schedule() }, delay))
+  }
+
+  return () => {
+    disposed = true
+    if (frame !== null && caf !== undefined) caf(frame)
+    if (nudgeFrame !== null && caf !== undefined) caf(nudgeFrame)
+    frame = null
+    nudgeFrame = null
+    pending = false
+    for (const timer of settleTimers) clearTimeout(timer)
+    settleTimers.length = 0
+    view.removeEventListener('resize', onViewportChange)
+    doc.removeEventListener('focusin', onViewportChange, true)
+    visual?.removeEventListener('resize', onViewportChange)
+    visual?.removeEventListener('scroll', onViewportChange)
+    if (keyboardMarked) root.removeAttribute(KEYBOARD_ATTRIBUTE)
+    keyboardMarked = false
+    if (heightWritten !== null) root.style.removeProperty(HEIGHT_PROPERTY)
+    if (topWritten !== null) root.style.removeProperty(TOP_PROPERTY)
+    heightWritten = null
+    topWritten = null
+    if (meta !== null && hinted && originalContent !== null) meta.setAttribute('content', originalContent)
+  }
+}

--- a/maid-atelier/tests/mobile-drawer.spec.ts
+++ b/maid-atelier/tests/mobile-drawer.spec.ts
@@ -8,13 +8,15 @@ interface Fixture {
   toggle: HTMLButtonElement
   row: HTMLElement
   rowAction: HTMLButtonElement
+  settingsButton: HTMLButtonElement
   dispose: () => void
 }
 
 /**
  * Build the layout shape the installer reads: a frame that drops
  * `data-sidebar-collapsed` while the narrow column is an overlay, plus a
- * decorated session row carrying DSH's nested actions control.
+ * decorated session row carrying DSH's nested actions control and the sidebar's
+ * own settings entry.
  */
 function mount(): Fixture {
   const frame = document.createElement('div')
@@ -33,7 +35,13 @@ function mount(): Fixture {
   rowAction.className = 'YDXeBa_iconButton'
   rowAction.setAttribute('aria-label', 'Session actions')
   row.append(rowAction)
-  column.append(toggle, row)
+  const settingsSlot = document.createElement('div')
+  settingsSlot.dataset.slot = 'sidebar.settings'
+  const settingsButton = document.createElement('button')
+  settingsButton.type = 'button'
+  settingsButton.setAttribute('aria-haspopup', 'dialog')
+  settingsSlot.append(settingsButton)
+  column.append(toggle, row, settingsSlot)
   frame.append(column)
   document.body.append(frame)
   return {
@@ -42,6 +50,7 @@ function mount(): Fixture {
     toggle,
     row,
     rowAction,
+    settingsButton,
     dispose: installMaidMobileDrawerAutoClose(document.body),
   }
 }
@@ -72,6 +81,14 @@ function mountOutside(): HTMLElement {
   outside.id = 'outside-the-drawer'
   document.body.append(outside)
   return outside
+}
+
+/** Mount the host dialog the sidebar's settings entry opens above the drawer. */
+function mountDialog(): HTMLElement {
+  const dialog = document.createElement('div')
+  dialog.setAttribute('role', 'dialog')
+  document.body.append(dialog)
+  return dialog
 }
 
 /** jsdom ships no PointerEvent; the installer only reads `isPrimary`/`button`. */
@@ -286,6 +303,84 @@ describe('Maid Atelier mobile drawer auto-close', () => {
     fixture.row.click()
     fixture.dispose()
     fixture.row.click()
+    await settle()
+
+    expect(toggleClick).not.toHaveBeenCalled()
+  })
+
+  it('closes the drawer when the settings dialog it opened is dismissed', async () => {
+    const fixture = mount()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    fixture.settingsButton.click()
+    const dialog = mountDialog()
+    await settle()
+    dialog.remove()
+    await settle()
+
+    expect(toggleClick).toHaveBeenCalledTimes(1)
+    fixture.dispose()
+  })
+
+  it('leaves the drawer up until the settings dialog has actually appeared', async () => {
+    const fixture = mount()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    // The click alone must not read as a dismissal: the host mounts the dialog
+    // a tick later and the reader is on their way into it.
+    fixture.settingsButton.click()
+    await settle()
+
+    expect(toggleClick).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('ignores a dialog it did not open from the settings entry', async () => {
+    const fixture = mount()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    const dialog = mountDialog()
+    await settle()
+    dialog.remove()
+    await settle()
+
+    expect(toggleClick).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('does not fold the collapsed rail when the settings dialog closes', async () => {
+    const fixture = mount()
+    setColumnWidth(fixture.column, 390)
+    fixture.frame.setAttribute('data-sidebar-collapsed', 'true')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    fixture.settingsButton.click()
+    const dialog = mountDialog()
+    await settle()
+    dialog.remove()
+    await settle()
+
+    expect(toggleClick).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('stops watching the settings dialog once disposed', async () => {
+    const fixture = mount()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    fixture.settingsButton.click()
+    const dialog = mountDialog()
+    await settle()
+    fixture.dispose()
+    dialog.remove()
     await settle()
 
     expect(toggleClick).not.toHaveBeenCalled()

--- a/maid-atelier/tests/mobile-drawer.spec.ts
+++ b/maid-atelier/tests/mobile-drawer.spec.ts
@@ -66,6 +66,27 @@ function setColumnWidth(column: HTMLElement, width: number): void {
   } as DOMRect)
 }
 
+/** A control that sits behind the open drawer, where a phone puts the composer. */
+function mountOutside(): HTMLElement {
+  const outside = document.createElement('div')
+  outside.id = 'outside-the-drawer'
+  document.body.append(outside)
+  return outside
+}
+
+/** jsdom ships no PointerEvent; the installer only reads `isPrimary`/`button`. */
+function pointerDown(target: Element, init: MouseEventInit = {}): MouseEvent {
+  const event = new MouseEvent('pointerdown', { bubbles: true, cancelable: true, button: 0, ...init })
+  target.dispatchEvent(event)
+  return event
+}
+
+function click(target: Element): MouseEvent {
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+  target.dispatchEvent(event)
+  return event
+}
+
 function settle(): Promise<void> {
   return new Promise(resolve => { setTimeout(resolve, 20) })
 }
@@ -133,6 +154,127 @@ describe('Maid Atelier mobile drawer auto-close', () => {
 
     expect(toggleClick).not.toHaveBeenCalled()
     fixture.dispose()
+  })
+
+  it('closes the drawer when the tap lands outside the column', async () => {
+    const fixture = mount()
+    const outside = mountOutside()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    pointerDown(outside)
+
+    expect(toggleClick).toHaveBeenCalledTimes(1)
+    fixture.dispose()
+  })
+
+  it('swallows the click a dismissing tap produced', async () => {
+    const fixture = mount()
+    const outside = mountOutside()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+    let reachedTarget = false
+    outside.addEventListener('click', () => { reachedTarget = true })
+
+    pointerDown(outside)
+    const mouse = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    outside.dispatchEvent(mouse)
+    const tapped = click(outside)
+
+    expect(toggleClick).toHaveBeenCalledTimes(1)
+    expect(mouse.defaultPrevented).toBe(true)
+    expect(tapped.defaultPrevented).toBe(true)
+    expect(reachedTarget).toBe(false)
+    fixture.dispose()
+  })
+
+  it('still dismisses for a click with no pointerdown in front of it', async () => {
+    const fixture = mount()
+    const outside = mountOutside()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    click(outside)
+
+    expect(toggleClick).toHaveBeenCalledTimes(1)
+    fixture.dispose()
+  })
+
+  it('keeps the drawer open for a tap inside the column', async () => {
+    const fixture = mount()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    pointerDown(fixture.toggle)
+    pointerDown(fixture.row)
+
+    expect(toggleClick).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('lets an open popup own the tap that dismisses it', async () => {
+    const fixture = mount()
+    const outside = mountOutside()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+    const menu = document.createElement('div')
+    menu.setAttribute('role', 'menu')
+    document.body.append(menu)
+
+    pointerDown(outside)
+
+    expect(toggleClick).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('ignores the host resize handle and secondary buttons', async () => {
+    const fixture = mount()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+    const handle = document.createElement('div')
+    handle.className = 'pI_x6G_handle'
+    document.body.append(handle)
+
+    pointerDown(handle)
+    pointerDown(handle, { button: 2 })
+
+    expect(toggleClick).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('does not dismiss the docked column on a desktop viewport', async () => {
+    const fixture = mount()
+    const outside = mountOutside()
+    setColumnWidth(fixture.column, 280)
+    setViewportWidth(1280)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    pointerDown(outside)
+    click(outside)
+
+    expect(toggleClick).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('stops dismissing outside taps once disposed', async () => {
+    const fixture = mount()
+    const outside = mountOutside()
+    setColumnWidth(fixture.column, 301)
+    fixture.frame.removeAttribute('data-sidebar-collapsed')
+    const toggleClick = vi.spyOn(fixture.toggle, 'click')
+
+    fixture.dispose()
+    pointerDown(outside)
+    click(outside)
+
+    expect(toggleClick).not.toHaveBeenCalled()
   })
 
   it('stops listening once disposed', async () => {

--- a/maid-atelier/tests/mobile-viewport.spec.ts
+++ b/maid-atelier/tests/mobile-viewport.spec.ts
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installMaidMobileViewport } from '../src/client/mobile-viewport.ts'
+
+interface VisualState {
+  height: number
+  offsetTop: number
+  scale: number
+}
+
+interface VisualHandle {
+  /** Registered listener types; the installer binds resize and scroll. */
+  registrations: string[]
+  set: (next: Partial<VisualState>) => void
+}
+
+/**
+ * jsdom ships no VisualViewport. Model the surface the installer reads —
+ * `height`, `offsetTop`, `scale` — plus the listeners it binds, so a test can
+ * drive a keyboard opening the way a browser reports it.
+ */
+function installVisualViewport(initial: VisualState): VisualHandle {
+  const state = { ...initial }
+  const listeners = new Map<string, Set<() => void>>()
+  const viewport = {
+    get height() { return state.height },
+    get offsetTop() { return state.offsetTop },
+    get scale() { return state.scale },
+    addEventListener(type: string, listener: () => void) {
+      if (type !== 'resize' && type !== 'scroll') return
+      const bucket = listeners.get(type) ?? new Set<() => void>()
+      bucket.add(listener)
+      listeners.set(type, bucket)
+    },
+    removeEventListener(type: string, listener: () => void) {
+      listeners.get(type)?.delete(listener)
+    },
+  }
+  Object.defineProperty(window, 'visualViewport', { configurable: true, value: viewport })
+  return {
+    get registrations() {
+      return [...listeners].flatMap(([type, bucket]) => [...bucket].map(() => type))
+    },
+    set(next) {
+      Object.assign(state, next)
+      for (const bucket of listeners.values()) {
+        for (const listener of bucket) listener()
+      }
+    },
+  }
+}
+
+/** jsdom reports 1024x768 for every window. */
+function setViewport(width: number, height: number): void {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: height })
+}
+
+function box(top: number, height: number, left = 20, width = 350): DOMRect {
+  return {
+    x: left,
+    y: top,
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+/** The composer's card, positioned where a phone would put it. */
+function mountComposerCard(top: number, height = 132): HTMLElement {
+  const card = document.createElement('div')
+  card.setAttribute('data-composer-card', '')
+  card.getBoundingClientRect = () => box(top, height, 16, 358)
+  document.body.append(card)
+  return card
+}
+
+function varOf(name: string): string {
+  return document.documentElement.style.getPropertyValue(name)
+}
+
+/** Let a queued animation frame and the settle timers run. */
+function flush(ms = 60): Promise<void> {
+  return new Promise(resolve => { setTimeout(resolve, ms) })
+}
+
+function viewportMeta(): HTMLMetaElement {
+  const meta = document.createElement('meta')
+  meta.setAttribute('name', 'viewport')
+  meta.setAttribute('content', 'width=device-width, initial-scale=1')
+  document.head.append(meta)
+  return meta
+}
+
+let disposers: Array<() => void> = []
+
+/** Install and register the disposer, so a failed assertion cannot leak listeners. */
+function install(): () => void {
+  const dispose = installMaidMobileViewport(document.body)
+  disposers.push(dispose)
+  return dispose
+}
+
+beforeEach(() => {
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+  disposers = []
+  setViewport(390, 844)
+})
+
+afterEach(() => {
+  for (const dispose of disposers) dispose()
+  disposers = []
+  document.documentElement.removeAttribute('data-maid-keyboard')
+  document.documentElement.removeAttribute('style')
+})
+
+describe('Maid Atelier phone viewport', () => {
+  it('measures the shell without pinning it while no keyboard is up', async () => {
+    installVisualViewport({ height: 844, offsetTop: 0, scale: 1 })
+    mountComposerCard(438)
+    install()
+    await flush()
+
+    expect(document.documentElement.hasAttribute('data-maid-keyboard')).toBe(false)
+    expect(varOf('--maid-vv-height')).toBe('844px')
+    expect(varOf('--maid-vv-top')).toBe('0px')
+  })
+
+  it('pins the shell once the keyboard takes a real slice of the viewport', async () => {
+    const visual = installVisualViewport({ height: 844, offsetTop: 0, scale: 1 })
+    mountComposerCard(438)
+    install()
+    await flush()
+
+    visual.set({ height: 404 })
+    await flush()
+
+    expect(document.documentElement.getAttribute('data-maid-keyboard')).toBe('open')
+    expect(varOf('--maid-vv-height')).toBe('404px')
+
+    visual.set({ height: 844 })
+    await flush()
+
+    expect(document.documentElement.hasAttribute('data-maid-keyboard')).toBe(false)
+  })
+
+  it('publishes the visual viewport offset the shell pins itself to', async () => {
+    const visual = installVisualViewport({ height: 844, offsetTop: 0, scale: 1 })
+    mountComposerCard(438)
+    install()
+    await flush()
+
+    visual.set({ height: 404, offsetTop: 24 })
+    await flush()
+
+    expect(varOf('--maid-vv-top')).toBe('24px')
+  })
+
+  it('pins the shell on a touch pointer even when the shell is wider than the phone breakpoint', async () => {
+    // Landscape phones are wider than 700px; the shell must still follow the
+    // keyboard because the pointer, not the width, makes it a phone.
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes('pointer: coarse'),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia
+    setViewport(844, 390)
+    installVisualViewport({ height: 180, offsetTop: 0, scale: 1 })
+    mountComposerCard(200)
+    install()
+    await flush()
+
+    expect(document.documentElement.getAttribute('data-maid-keyboard')).toBe('open')
+    expect(varOf('--maid-vv-height')).toBe('180px')
+  })
+
+  it('keeps the shell alone while the viewport is only pinch-zoomed', async () => {
+    installVisualViewport({ height: 400, offsetTop: 0, scale: 1.8 })
+    mountComposerCard(438)
+    install()
+    await flush()
+
+    expect(document.documentElement.hasAttribute('data-maid-keyboard')).toBe(false)
+  })
+
+  it('brings a composer that the keyboard left below the fold back into the band', async () => {
+    const visual = installVisualViewport({ height: 844, offsetTop: 0, scale: 1 })
+    const card = mountComposerCard(438, 140)
+    const scrollIntoView = vi.fn()
+    card.scrollIntoView = scrollIntoView
+    install()
+    await flush()
+
+    visual.set({ height: 422 })
+    await flush()
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not move a composer that already fits inside the band', async () => {
+    const visual = installVisualViewport({ height: 844, offsetTop: 0, scale: 1 })
+    const card = mountComposerCard(438, 140)
+    const scrollIntoView = vi.fn()
+    card.scrollIntoView = scrollIntoView
+    install()
+    await flush()
+
+    // The shell pin is what moves the card up; jsdom does not lay out, so model
+    // the pinned position the browser would produce before the keyboard opens.
+    card.getBoundingClientRect = () => box(227, 140, 16, 358)
+    visual.set({ height: 422 })
+    await flush()
+
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it('appends the resize hint once and gives the host tag back on dispose', async () => {
+    const meta = viewportMeta()
+    installVisualViewport({ height: 844, offsetTop: 0, scale: 1 })
+    mountComposerCard(438)
+    const dispose = install()
+    await flush()
+
+    const hinted = meta.getAttribute('content') ?? ''
+    expect(hinted).toContain('interactive-widget=resizes-content')
+    expect(hinted.match(/interactive-widget/g)).toHaveLength(1)
+
+    dispose()
+    expect(meta.getAttribute('content')).toBe('width=device-width, initial-scale=1')
+  })
+
+  it('gives back every variable, attribute and listener on dispose', async () => {
+    const visual = installVisualViewport({ height: 404, offsetTop: 12, scale: 1 })
+    mountComposerCard(300)
+    const dispose = install()
+    await flush()
+
+    // VisualViewport resize and scroll; no document scroll listener exists,
+    // because nothing here depends on the transcript's scroll position.
+    expect(visual.registrations).toEqual(['resize', 'scroll'])
+    expect(varOf('--maid-vv-height')).toBe('404px')
+
+    dispose()
+
+    expect(visual.registrations).toEqual([])
+    expect(varOf('--maid-vv-height')).toBe('')
+    expect(varOf('--maid-vv-top')).toBe('')
+    expect(document.documentElement.hasAttribute('data-maid-keyboard')).toBe(false)
+  })
+
+  it('stops updating once disposed', async () => {
+    const visual = installVisualViewport({ height: 844, offsetTop: 0, scale: 1 })
+    mountComposerCard(438)
+    const dispose = install()
+    await flush()
+    dispose()
+
+    visual.set({ height: 404 })
+    await flush()
+
+    expect(document.documentElement.hasAttribute('data-maid-keyboard')).toBe(false)
+    expect(varOf('--maid-vv-height')).toBe('')
+  })
+})


### PR DESCRIPTION
# fix(mobile): five phone defects — prompt card, software keyboard, drawer dismissal, model picker, settings hand-off

Branch: **`fix/mobile-phone-fixes`** (5 commits on top of `origin/main` @ `daa6c69`) · +962/−9 · 6 files
Base: `Small-tailqwq/dsh-deep-whale` → `maid-atelier/`

Five independent phone defects, split out of the navigation proposal in #122 so
that evaluating them does not require accepting any redesign. **This PR contains
no navigation change**: on this branch the collapsed sidebar is still the host's
56px rail, and there is no dock CSS, no navigation mode value and no navigation
module or test.

| # | Commit | Fix |
|---|---|---|
| 1 | `ff4a437` | the prompt card (`ask_user_question` / plan review) clipped its own actions |
| 2 | `431f64f` | the shell and composer stayed behind the software keyboard |
| 3 | `2f2e02a` | the narrow sidebar never dismissed on a tap outside it |
| 4 | `1cc5edf` | the icon-only model picker stretched across the composer |
| 5 | `8dcf9ed` | closing the settings dialog left the drawer covering the composer |

The five commits do not depend on each other. 1 and 4 are stylesheet-only, 2 is
the keyboard module plus its stylesheet block, 3 and 5 extend the drawer module
#119 introduced; each can be reviewed, reverted or cherry-picked on its own.

## 1 · The phone prompt card clipped its own actions

`ask_user_question` and the plan review take the composer seat over. Their footer
is one non-wrapping row — pager, status text, Skip and Submit — and at 390px that
row measures **349px inside a 318px card**: the primary button is pushed past the
card's right edge and clipped by the card's own `overflow: hidden`. At 360px its
centre falls outside the card and the tap misses it entirely.

| | 390x844 | 360x740 | 412x915 |
|---|---|---|---|
| card width before → after | 318 → **362** | 302 → **332** | 340 → **384** |
| footer overflow before | 31px clipped | 47px clipped | 9px clipped |
| footer overflow after | **none** | **none** | **none** |
| Submit before | 72x36, right edge at 385 (card ends at 354) | centre outside the card | partially clipped |
| Submit after | **166x44, inside the card** | **151x44, hit-test passes** | **177x44, inside** |

The phone breakpoint drops the desktop gutters, wraps the footer into a pager row
and a full-width action row of 44px targets, grows the option rows and the
icon-only affordances with it, and caps the card against the visual viewport
rather than the layout viewport the keyboard does not shrink. The hooks are the
components' own — `data-question-key`, `data-plan-review-key` and their `*scroll`
bodies — so no hashed CSS-module class name is involved.

## 2 · The shell stayed behind the software keyboard

`html`, `body` and `#root` are height-locked to the layout viewport, and the
layout viewport does not shrink for the software keyboard — iOS never does, and
Android only when the page opts in through the `interactive-widget` viewport
hint. The height-locked page has no scroll range to bring the composer back
either. With the keyboard at 422px of an 844px phone, the composer's bottom sits
158px behind it.

The client entry appends `interactive-widget=resizes-content` where the engine
accepts it, and when the keyboard still shrinks only the visual viewport it
publishes `--maid-vv-height` / `--maid-vv-top` and marks the root so the
stylesheet pins the shell to the band `VisualViewport` reports. The same pass
brings the composer back into the band once per keyboard opening, which is what a
landscape phone needs: its hero stack is centred and taller than the band, so the
composer would otherwise sit below the fold.

| composer fully inside the visible band | 390x844 | 360x740 | 412x915 | 844x390 |
|---|---|---|---|---|
| with this commit | **yes** | **yes** | **yes** | **yes** |
| the host alone (marker removed in the same session) | no — 158px behind | no | no | no |

Every write is idempotent and remembered, so a viewport that stops changing stops
writing; the disposer removes the listeners, the published variables and the
viewport hint it appended — and nothing else. There is deliberately no document
`scroll` listener: nothing here depends on the transcript's scroll position.

## 3 · The narrow sidebar never dismissed on a tap outside it

`@deepseek-ai/dsh-client-ui-layout` closes its narrow sidebar only from the
toggle button. Its `overlayLayer` is an overlay container — `pointer-events:
none`, no handler — not a scrim, so on a phone the drawer stays up until the
toggle is found again, and a tap on the conversation ignores it. Measured in the
host's own `rail` layout as well, so this is a host gap rather than a regression
from anything here.

A pointer that lands outside the open column now closes it, and the click that
pointer produced is swallowed: behind the drawer is usually the composer, whose
send control sits exactly in the corner a reader aims at when dismissing, so the
first tap must only dismiss. Cancelling `mousedown` keeps that tap from focusing —
and so from raising the phone keyboard on — whatever is behind.

Gestures that still belong to the drawer are left alone: anything inside the
column, anything inside an open popup (menu, listbox, dialog), and the host's
resize handle. A docked column (`innerWidth >= 1024`) never dismisses.

| measured at 390x844, in all three phone layouts | result |
|---|---|
| mouse / touch tap outside | drawer **closes** |
| the click it produced | **swallowed** — nothing behind is reached |
| focus after the dismissing tap | **unchanged** (no keyboard flicker) |
| tap inside the drawer | stays open, its own click is delivered |
| toggle button | still closes it |
| console errors | 0 |

## 4 · The icon-only model picker stretched across the composer

The host drops the model name in a narrow composer — its own stylesheet hides
`triggerLabel` / `triggerEffort` and shows `triggerIcon` inside
`@container (width<=360px)`. The skin's phone rules still sized the picker to the
whole model seat (`flex: 1 1 0` on the seat root, `width: 100%` on the button),
which is right while a name fills it, but once the name is gone the chip kept a
text-sized box: at 390x844 it measured **198px with its icon at the left and
164px of empty tail**, so it read as a wide, left-aligned pill sitting mid-row.

| | before | after |
|---|---|---|
| chip 390x844 | 198px, icon at x=134, tail 164px | **44px**, icon at x=294, tail 4px |
| chip 360x740 | 170px | **44px** |
| chip 412x915 (the host *does* show the name here) | 220px with label | **220px — unchanged** |
| send button | x=334..366 | **x=334..366 — unchanged** |

The rules are gated on the host's own `@container (width<=360px)` condition, so
nothing changes where the name is visible, and `trailing` keeps its default
alignment there.

## 5 · Closing the settings dialog left the drawer covering the composer

The sidebar's settings entry opens the host dialog *above* the drawer overlay.
Closing that dialog dropped the reader straight back onto the expanded drawer —
301px of a 390px viewport — which covers the composer. Tapping the prompt then
landed on a session row, `document.activeElement` stayed on `BODY`, and nothing
could be typed until the reader worked out that they had to tap the conversation
area first. Reported as "I can't type anything after changing a setting in the
manager", and reproduced at 390x844 in all three phone layouts:

| after closing the dialog | before | after |
|---|---|---|
| `colW` (corner / topbar / rail) | 301 / 301 / 280 | **48 / 390 / 56** |
| `elementFromPoint` at the composer | a session row title | **the composer input** |
| typing right away | nothing, `activeElement = BODY` | **the text lands in the composer** |

`installMaidMobileDrawerAutoClose` already owns the two neighbouring gestures
(session pick, outside tap), so this is the third one rather than a second
mechanism. The settings trigger arms a `MutationObserver` that only starts
counting once the dialog has actually been on screen, so the tick between the
click and the host mounting it cannot be read as a dismissal, and a 4s timeout
drops the observer if the dialog never opens. Only the
`[data-slot='sidebar.settings']` trigger arms it, so a session row's own actions
menu — also `role="dialog"` — is unaffected, and a collapsed rail has nothing to
close. The disposer removes the observer and its timer.

## Verification

- `vitest run` in the scaffolding checkout: **9 files, 185 tests pass** — 180
  before commit 5, plus the 5 cases it adds. The new `tests/mobile-drawer.spec.ts`
  cases (18 in total) cover outside dismissal and the swallowed click, the popup
  and handle guards, disposal, and the settings hand-off of commit 5; the new
  `tests/mobile-viewport.spec.ts` cases (10) cover the keyboard threshold, visual
  viewport offset, pinch-zoom ignored, coarse-pointer landscape, composer nudge
  and disposal. The 5 cases added in commit 5 fail against the implementation of
  commit 3, which is what makes them worth having.
- The fixes-only bundle — the one this PR builds — rendered in Chromium at
  390x844, 360x740, 412x915 and 844x390: the numbers above hold, `scrollWidth ==
  viewport` and **0 console/page errors** in every state.
- The bundle rebuilt from this branch is byte-identical to the build those numbers
  were measured on, and the same four fixes were re-verified composed with the
  navigation proposal to make sure nothing here depends on it.

## Not changed

Navigation and the sidebar's own layout, the composer's behaviour, the settings
dialog itself (commit 5 only reacts to it closing), and every width above 700px. The keyboard block is gated on
`pointer: coarse`; the prompt-card and picker rules are gated on phone widths and
on the host's own container condition.

## Build output

`lib/` is not included, same as #119/#120: `npm run build` cannot run outside the
scaffolding checkout (`src/client/customization.ts` resolves
`../../../skin-manager/src/protocol.ts`, and the build script calls
`../scripts/write-skin-build.mjs`). Regenerate the bundles where the full tree is
available; `skin.build.json` follows from `npm run build`.
