### PR TITLE
fix(skin-manager): follow the host language in the settings nav label

### DIFF
--- a/skin-manager/lib/client.js
+++ b/skin-manager/lib/client.js
@@ -39,8 +39,16 @@ window.__ModuleLoader__.load({
 		function uiLangSnapshot() {
 			return detectUiLang();
 		}
-		/** Settings-section markup renders through getServerSnapshot; node-side calls have no DOM. */
-		function serverUiLang() {
+		/**
+		* Live read for every caller that is not a React render: the settings-section
+		* server snapshot, and — the reason this is exported — slot labels. A
+		* `settings.section` label is a plain function the host calls itself, so the
+		* manager cannot subscribe for it the way `useUiLang` does; the host
+		* recomputes labels on its own locale revision and this read then picks the
+		* repointed `<html lang>` up. Node-side calls have no DOM and degrade to the
+		* source language.
+		*/
+		function currentUiLang() {
 			try {
 				return detectUiLang();
 			} catch {
@@ -66,10 +74,11 @@ window.__ModuleLoader__.load({
 			};
 		}
 		function useUiLang() {
-			return (0, react.useSyncExternalStore)(subscribeUiLang, uiLangSnapshot, serverUiLang);
+			return (0, react.useSyncExternalStore)(subscribeUiLang, uiLangSnapshot, currentUiLang);
 		}
 		const zhCopy = {
 			headerTitle: "皮肤管理",
+			navLabel: "皮肤管理",
 			headerIntro: "这里会发现当前 Web profile 中已安装的皮肤。激活由管理器统一处理；详细配置由皮肤按通用协议自行声明并负责应用。每个皮肤下方显示本地提交或构建指纹；「检查更新」只比较官方仓库的构建结果，不会改动你的本地文件。",
 			installedTitle: "已安装皮肤",
 			checking: "检查中…",
@@ -114,6 +123,7 @@ window.__ModuleLoader__.load({
 		};
 		const enCopy = {
 			headerTitle: "Skin Management",
+			navLabel: "Skins",
 			headerIntro: "This page discovers the skins installed in the current Web profile. Activation is handled by the manager; detailed options are declared and applied by each skin over a shared protocol. Every skin lists its local commit or build fingerprint below. \"Check updates\" only compares against the official repository's build results and never touches your local files.",
 			installedTitle: "Installed Skins",
 			checking: "Checking…",
@@ -1286,7 +1296,7 @@ window.__ModuleLoader__.load({
 				name: "settings.section",
 				id: "dsh-skins",
 				order: 115,
-				label: "皮肤管理",
+				label: () => skinManagerCopy(currentUiLang()).navLabel,
 				inject: () => ({
 					registry,
 					active: activeSkin,

--- a/skin-manager/src/client/index.ts
+++ b/skin-manager/src/client/index.ts
@@ -2,6 +2,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import type { SkinCatalogEntry } from '../contract.ts'
 import { SkinManager, requestSkinSwitch } from './SkinManager.tsx'
+import { currentUiLang, skinManagerCopy } from './locale.ts'
 import { PreferencesStore } from './preferences.ts'
 import { SkinCustomizationRegistry } from './runtime.ts'
 import './skin-manager.module.css'
@@ -30,7 +31,12 @@ export function apply(ctx: SlotsContext): void {
     name: 'settings.section',
     id: 'dsh-skins',
     order: 115,
-    label: '皮肤管理',
+    // A label the host calls during render, so the settings nav follows the
+    // host language instead of staying on the Chinese source string. The host
+    // re-invokes it on every locale revision, which is when this re-reads
+    // <html lang>; the page itself follows through `useUiLang`. The nav cell is
+    // narrow and ellipsises, hence the dedicated short `navLabel`.
+    label: () => skinManagerCopy(currentUiLang()).navLabel,
     inject: () => ({ registry, active: activeSkin, switchSkin: requestSkinSwitch }),
   }, SkinManager))
 }

--- a/skin-manager/src/client/locale.ts
+++ b/skin-manager/src/client/locale.ts
@@ -36,8 +36,16 @@ export function uiLangSnapshot(): UiLang {
   return detectUiLang()
 }
 
-/** Settings-section markup renders through getServerSnapshot; node-side calls have no DOM. */
-function serverUiLang(): UiLang {
+/**
+ * Live read for every caller that is not a React render: the settings-section
+ * server snapshot, and — the reason this is exported — slot labels. A
+ * `settings.section` label is a plain function the host calls itself, so the
+ * manager cannot subscribe for it the way `useUiLang` does; the host
+ * recomputes labels on its own locale revision and this read then picks the
+ * repointed `<html lang>` up. Node-side calls have no DOM and degrade to the
+ * source language.
+ */
+export function currentUiLang(): UiLang {
   try {
     return detectUiLang()
   } catch {
@@ -62,7 +70,7 @@ export function subscribeUiLang(listener: () => void): () => void {
 }
 
 export function useUiLang(): UiLang {
-  return useSyncExternalStore(subscribeUiLang, uiLangSnapshot, serverUiLang)
+  return useSyncExternalStore(subscribeUiLang, uiLangSnapshot, currentUiLang)
 }
 
 /* ------------------------------------------------------------------ */
@@ -72,6 +80,10 @@ export function useUiLang(): UiLang {
 
 const zhCopy = {
   headerTitle: '皮肤管理',
+  // The settings nav gives every section a narrow two-column cell and ellipsises
+  // the overflow, so the nav label is its own, shorter string rather than the
+  // page heading: "Skin Management" would render as "Skin Manage…".
+  navLabel: '皮肤管理',
   headerIntro: '这里会发现当前 Web profile 中已安装的皮肤。激活由管理器统一处理；详细配置由皮肤按通用协议自行声明并负责应用。每个皮肤下方显示本地提交或构建指纹；「检查更新」只比较官方仓库的构建结果，不会改动你的本地文件。',
   installedTitle: '已安装皮肤',
   checking: '检查中…',
@@ -117,6 +129,7 @@ const zhCopy = {
 
 const enCopy: typeof zhCopy = {
   headerTitle: 'Skin Management',
+  navLabel: 'Skins',
   headerIntro: 'This page discovers the skins installed in the current Web profile. Activation is handled by the manager; detailed options are declared and applied by each skin over a shared protocol. Every skin lists its local commit or build fingerprint below. "Check updates" only compares against the official repository\'s build results and never touches your local files.',
   installedTitle: 'Installed Skins',
   checking: 'Checking…',

--- a/skin-manager/tests/section-label.spec.ts
+++ b/skin-manager/tests/section-label.spec.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { apply } from '../src/client/index.ts'
+import { skinManagerCopy } from '../src/client/locale.ts'
+
+interface SectionOptions {
+  id?: string
+  label?: unknown
+}
+
+/** Run `apply` against the smallest ctx the settings section needs. */
+function registerSection(): SectionOptions {
+  const entries: SectionOptions[] = []
+  const ctx = {
+    effect: (fn: () => unknown) => fn(),
+    slots: {
+      inject: (_name: string, register: () => unknown) => { register() },
+      register: (options: SectionOptions) => { entries.push(options); return options },
+    },
+  }
+  apply(ctx as unknown as Parameters<typeof apply>[0])
+  const entry = entries[0]
+  if (entry === undefined) throw new Error('no settings section registered')
+  return entry
+}
+
+const originalLanguage = window.navigator.language
+
+afterEach(() => {
+  document.documentElement.lang = ''
+  Object.defineProperty(window.navigator, 'language', { value: originalLanguage, configurable: true })
+})
+
+describe('settings section label', () => {
+  it('is a function, so the host can re-evaluate it on every locale revision', () => {
+    document.documentElement.lang = 'zh-CN'
+    expect(typeof registerSection().label).toBe('function')
+  })
+
+  it('follows the host language instead of staying on the Chinese source string', () => {
+    document.documentElement.lang = 'zh-CN'
+    const label = registerSection().label as () => string
+    expect(label()).toBe('皮肤管理')
+
+    document.documentElement.lang = 'en'
+    expect(label()).toBe('Skins')
+
+    // The host calls the same function again after another switch: no caching
+    // of the first read, and no re-registration needed.
+    document.documentElement.lang = 'zh-TW'
+    expect(label()).toBe('皮肤管理')
+    document.documentElement.lang = 'en-US'
+    expect(label()).toBe('Skins')
+  })
+
+  it('uses a short nav label that survives the settings cell', () => {
+    // The host lays the sections out as 144px cells and ellipsises the
+    // overflow, so the page heading would render as "Skin Manage…". The nav
+    // label is a separate, shorter string for exactly that reason.
+    expect(skinManagerCopy('en').navLabel).toBe('Skins')
+    expect(skinManagerCopy('en').navLabel.length).toBeLessThan(skinManagerCopy('en').headerTitle.length)
+    expect(skinManagerCopy('en').navLabel.length).toBeLessThanOrEqual(12)
+    expect(skinManagerCopy('zh').navLabel).toBe('皮肤管理')
+  })
+
+  it('falls back to the navigator language when <html lang> is empty', () => {
+    Object.defineProperty(window.navigator, 'language', { value: 'en-GB', configurable: true })
+    const label = registerSection().label as () => string
+    expect(label()).toBe('Skins')
+  })
+})


### PR DESCRIPTION
## 改动内容 / What this changes

The settings section was registered with a static label:

```ts
label: '皮肤管理',
```

so the settings nav entry stayed Chinese in every other host language, even though the page behind it was already bilingual. The host resolves a slot label with `resolveSlotLabel(options.label)` (`dsh-client-ui-slots`) — `typeof label === 'function' ? label() : label` — and `ui-settings-general` rebuilds the nav rows whenever the `ctx.locale` revision changes, so the label only has to become a function. That is also what every first-party section does (`label: () => t("nav")`).

```ts
label: () => skinManagerCopy(currentUiLang()).navLabel,
```

- `src/client/locale.ts` now exports `currentUiLang()` — the DOM-less-safe read that used to be the private `serverUiLang`, and is still the `getServerSnapshot` for `useUiLang`. `<html lang>` first, `navigator.language` as fallback, any `zh*` tag counting as Chinese.
- `navLabel` is a new copy key (`皮肤管理` / `Skins`) rather than `headerTitle`. The host lays the settings sections out as 144px cells and ellipsises the overflow, so reusing the page heading rendered the English entry as **"Skin Manage…"** — `Skins` fits the cell and still matches the "Skin Management" heading directly below it.
- `lib/client.js` regenerated with `npx tsdown`. This package ships as committed build output and is installed straight from the repository as a GitHub path (`github:Small-tailqwq/dsh-deep-whale#path:/skin-manager`), so nothing rebuilds it at install time.

Independent of #122 and #124: this touches `skin-manager/` only, which neither of those branches changes.

## 验证 / Verification

- `npx vitest run` → **7 files, 64 tests pass**. New `tests/section-label.spec.ts` (4 tests) asserts the label is a function, follows `<html lang>` in both directions across repeated calls, falls back to `navigator.language` when `<html lang>` is empty, and that `navLabel` stays shorter than `headerTitle` (≤ 12 Latin characters) for the 144px cell.
- The committed `lib/client.js` is plain `npx tsdown` output: rebuilding from the committed source leaves the working tree clean.
- Checked in a running GUI at 390x844 with the host on `lang="en"`: the settings nav reads `General, Models, Plugins, Agent presets, Plugin Market, Side card, `**`Skins`**, and the page heading is still "Skin Management". With `<html lang>` back on `zh-CN` the entry stays `皮肤管理`.
