### PR TITLE
feat(mobile): make the phone navigation layout a setting with three modes

### DIFF
--- a/maid-atelier/src/client/customization.ts
+++ b/maid-atelier/src/client/customization.ts
@@ -10,6 +10,9 @@ const ATTR_FONT = 'data-dsh-whale-maid-font'
 const ATTR_MODEL_EXIT = 'data-dsh-whale-maid-model-exit'
 const ATTR_MODEL = 'data-dsh-whale-model'
 const ATTR_COMPOSER_MODE = 'data-maid-composer-mode'
+const ATTR_NAV_MODE = 'data-maid-nav-mode'
+/** Navigation layouts the stylesheet implements; anything else falls back to the default. */
+const NAV_MODES = new Set(['corner', 'topbar', 'rail'])
 
 export function modelFamily(name: string): 'pro' | 'flash' | 'flash-vision' | null {
   const compact = name.toLowerCase().replace(/[^a-z0-9]/g, '')
@@ -112,6 +115,8 @@ export function installMaidCustomization(root: HTMLElement = document.documentEl
     projector.set(ATTR_FONT, state.values.font === 'serif' ? 'serif' : 'system')
     synchronizeModelMode()
     projector.set(ATTR_COMPOSER_MODE, typeof state.values.composerMode === 'string' ? state.values.composerMode : 'persistent')
+    const navMode = state.values.mobileNav
+    projector.set(ATTR_NAV_MODE, typeof navMode === 'string' && NAV_MODES.has(navMode) ? navMode : 'corner')
   }
 
   return exposeSkinCustomization({
@@ -160,6 +165,20 @@ export function installMaidCustomization(root: HTMLElement = document.documentEl
         label: '移动端根据所选模型显示立绘',
         labelEn: 'Show artwork based on the selected model on mobile',
         defaultValue: true,
+      },
+      {
+        key: 'mobileNav',
+        type: 'select',
+        label: '移动端导航方式',
+        labelEn: 'Phone navigation layout',
+        description: '仅影响竖屏手机（宽度 ≤700px）：左上角品牌图标（默认）、横向顶栏，或宿主原本的纵向侧栏。桌面与横屏不受影响。',
+        descriptionEn: 'Portrait phones only (≤700px wide): a brand mark in the top-left corner (default), a horizontal top bar, or the host\u2019s own vertical column. Desktop and landscape are untouched.',
+        defaultValue: 'corner',
+        options: [
+          { value: 'corner', label: '左上角品牌图标', labelEn: 'Brand mark · top-left corner' },
+          { value: 'topbar', label: '横向顶栏', labelEn: 'Horizontal top bar' },
+          { value: 'rail', label: '纵向侧栏（宿主默认）', labelEn: 'Vertical column (host default)' },
+        ],
       },
       {
         key: 'composerMode',

--- a/maid-atelier/src/client/maid-atelier.module.css
+++ b/maid-atelier/src/client/maid-atelier.module.css
@@ -1500,6 +1500,441 @@ body[data-dsh-maid-atelier][data-maid-sidebar-size='rail']
   box-shadow: none;
 }
 
+/* ---------------------------------------------------------------------------
+   Phone navigation layout — one skin customization value, three modes.
+
+   The host pins its collapsed rail to the left edge as a 56px column, so at
+   390x844 the conversation column measures 334px: 14% of the viewport spent on
+   a strip whose only always-useful control is the toggle that opens the column.
+   `data-maid-nav-mode` (owned by installMaidCustomization) picks what phone
+   portrait does instead:
+
+     corner  (skin default) the toggle becomes a 48px brand button in the
+             top-left corner, clear of the host's own header row; the rest of
+             the column's chrome stays one tap away in the drawer.
+     topbar  the same chrome spread as a 48px bar across the top.
+     rail    no rule below matches, so the host's own column is untouched.
+
+   The mode travels on `data-maid-nav-mode` on the document element, which is
+   where `SkinAttributeProjector` writes and where the manager may not have
+   pushed a value yet — on a fresh load, or on an install without the manager.
+   So `corner` is what the selectors below mean by *absence*: only `topbar` and
+   `rail` need an explicit value, and a missing attribute still gives a phone the
+   skin's default layout.
+
+   Hooks are the host's own: `data-sidebar-collapsed` on the AppFrame is its
+   marker for "the column is the rail", `sidebarCol` is the class the rest of
+   this file already matches on, and `logoRow` / `toggle` / `panelList` /
+   `newSession` / `settingsArea` are its names. The `@supports` arm covers
+   engines without relational selectors. Everything the expanded column already
+   offers is hidden by matching *siblings of `logoRow`* rather than a list of
+   class names, so a later build cannot re-introduce a row into the corner
+   button. `z-index: 40` stays inside the host's layer contract (menu 100 /
+   modal 1000).
+
+   Portrait only: in landscape the scarce axis is height, so the rail's 56px of
+   width is the cheaper trade and every mode below leaves the host alone. */
+@media (max-width: 700px) and (orientation: portrait) {
+  /* Frame: one column, conversation only. The column is out of flow in both
+     states — collapsed it is the dock or the bar, expanded it is the overlay
+     drawer — so the frame must never keep the track it vacated, or the host grid
+     would place the conversation in that track and leave an empty strip beside
+     the drawer. `:has` identifies the expanded frame; the collapsed frame keeps
+     the host's own `data-sidebar-collapsed` marker, which needs no support arm. */
+  html:not([data-maid-nav-mode='rail']) body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed],
+  html:not([data-maid-nav-mode='rail']) body[data-dsh-maid-atelier]
+    div:not([data-sidebar-collapsed]):has(> :is([data-pane='sidebar'], [class*='sidebarCol'])) {
+    display: flex !important;
+    flex-direction: column !important;
+    grid-template-columns: none !important;
+    grid-template-rows: none !important;
+    height: 100% !important;
+    min-height: 0 !important;
+  }
+
+  html:not([data-maid-nav-mode='rail']) body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    > :is([class*='centerCol'], [data-pane='conversation']),
+  html:not([data-maid-nav-mode='rail']) body[data-dsh-maid-atelier]
+    div:not([data-sidebar-collapsed]):has(> :is([data-pane='sidebar'], [class*='sidebarCol']))
+    > :is([class*='centerCol'], [data-pane='conversation']) {
+    flex: 1 1 auto !important;
+    width: 100% !important;
+    min-height: 0 !important;
+  }
+
+  /* -- corner ------------------------------------------------------------- */
+  /* A fixed 48px brand button in the top-left. The box itself stays inert so it
+     never eats a tap meant for the header behind it; only the toggle inside it
+     is interactive. */
+  html:not([data-maid-nav-mode='topbar']):not([data-maid-nav-mode='rail'])
+    body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) {
+    position: fixed !important;
+    top: calc(env(safe-area-inset-top, 0px) + 6px) !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: 10px !important;
+    order: 0 !important;
+    box-sizing: border-box !important;
+    width: 48px !important;
+    min-width: 48px !important;
+    max-width: 48px !important;
+    height: 48px !important;
+    min-height: 48px !important;
+    max-height: 48px !important;
+    flex: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: none !important;
+    box-shadow: none !important;
+    overflow: visible !important;
+    pointer-events: none !important;
+    z-index: 40 !important;
+  }
+
+  /* One centred row inside the button: the logo row and nothing else. */
+  html:not([data-maid-nav-mode='topbar']):not([data-maid-nav-mode='rail'])
+    body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    :is(div:has(> [class*='logoRow']), [class*='logoRow']) {
+    box-sizing: border-box !important;
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: center !important;
+    gap: 0 !important;
+    width: 48px !important;
+    min-width: 0 !important;
+    height: 48px !important;
+    min-height: 48px !important;
+    max-height: 48px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    flex: none !important;
+    overflow: visible !important;
+    pointer-events: none !important;
+  }
+
+  html:not([data-maid-nav-mode='topbar']):not([data-maid-nav-mode='rail'])
+    body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    div:has(> [class*='logoRow']) > :not([class*='logoRow']) {
+    display: none !important;
+  }
+
+  @supports not (selector(:has(*))) {
+    html:not([data-maid-nav-mode='topbar']):not([data-maid-nav-mode='rail'])
+    body[data-dsh-maid-atelier]
+      div[data-sidebar-collapsed]
+      :is([data-pane='sidebar'], [class*='sidebarCol']) > div {
+      box-sizing: border-box !important;
+      display: flex !important;
+      flex-direction: row !important;
+      align-items: center !important;
+      justify-content: center !important;
+      width: 48px !important;
+      height: 48px !important;
+      min-height: 48px !important;
+      max-height: 48px !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      overflow: visible !important;
+      pointer-events: none !important;
+    }
+
+    html:not([data-maid-nav-mode='topbar']):not([data-maid-nav-mode='rail'])
+    body[data-dsh-maid-atelier]
+      div[data-sidebar-collapsed]
+      :is([data-pane='sidebar'], [class*='sidebarCol'])
+      > div > :not([class*='logoRow']) {
+      display: none !important;
+    }
+  }
+
+  /* The toggle is the whole target and the only interactive thing left. The rail
+     variant already paints it as a gold-ringed navy medallion, so this only
+     sizes it and hands it the pointer. */
+  html:not([data-maid-nav-mode='topbar']):not([data-maid-nav-mode='rail'])
+    body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    [class*='logoRow'] button[class*='toggle'] {
+    box-sizing: border-box !important;
+    width: 48px !important;
+    min-width: 48px !important;
+    height: 48px !important;
+    min-height: 48px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    place-items: center !important;
+    justify-content: center !important;
+    pointer-events: auto !important;
+    cursor: pointer !important;
+  }
+
+  /* The host header keeps its own row, its own order and its own behaviour; it
+     only starts after the button. The host pads it `10px 28px 0 20px`, so 64px
+     clears the 48px button (10px + 48px) and leaves the title row intact. */
+  html:not([data-maid-nav-mode='topbar']):not([data-maid-nav-mode='rail'])
+    body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='conversation'], [class*='centerCol'])
+    header[class*='header'] {
+    padding-left: 64px !important;
+  }
+
+  /* -- topbar ------------------------------------------------------------- */
+  /* The collapsed column becomes a 48px bar across the top, above the
+     conversation. The column is full width now, so the width-based
+     `data-maid-sidebar-size` heuristic reports `wide` and the framed wide
+     trigger/plaque styling would be squeezed into the bar; it therefore gets its
+     own compact round targets (36px), matching the rail variant below. */
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) {
+    order: -1 !important;
+    width: 100% !important;
+    height: calc(48px + env(safe-area-inset-top, 0px)) !important;
+    min-height: calc(48px + env(safe-area-inset-top, 0px)) !important;
+    max-height: calc(48px + env(safe-area-inset-top, 0px)) !important;
+    flex: none !important;
+    padding-top: env(safe-area-inset-top, 0px) !important;
+    border-right: none !important;
+    border-bottom: 0.5px solid var(--dsw-alias-border-l3) !important;
+    overflow: visible !important;
+  }
+
+  /* The sidebar root below the host's slot anchor: one horizontal row. */
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    div:has(> [class*='logoRow']) {
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: 4px !important;
+    width: 100% !important;
+    height: 48px !important;
+    min-height: 48px !important;
+    max-height: 48px !important;
+    padding: 0 8px !important;
+    overflow: visible !important;
+  }
+
+  @supports not (selector(:has(*))) {
+    html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+      div[data-sidebar-collapsed]
+      :is([data-pane='sidebar'], [class*='sidebarCol']) > div {
+      display: flex !important;
+      flex-direction: row !important;
+      align-items: center !important;
+      gap: 4px !important;
+      height: 48px !important;
+      min-height: 48px !important;
+      padding: 0 8px !important;
+      overflow: visible !important;
+    }
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) [class*='logoRow'] {
+    height: 48px !important;
+    min-height: 48px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    flex: none !important;
+    border: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) [class*='panelList'] {
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: 2px !important;
+    margin: 0 !important;
+    flex: none !important;
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) [class*='panelRow'] {
+    width: 36px !important;
+    height: 36px !important;
+    min-height: 36px !important;
+    padding: 0 !important;
+    justify-content: center !important;
+  }
+
+  /* New Session is a framed plaque in the column; in the bar it is a round icon
+     target with the rail variant's ink so the glyph stays legible. */
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) button[class*='newSession'] {
+    box-sizing: border-box !important;
+    width: 36px !important;
+    min-width: 36px !important;
+    height: 36px !important;
+    min-height: 36px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    align-self: center !important;
+    justify-content: center !important;
+    border: 1px solid rgba(225, 207, 170, 0.72) !important;
+    border-image: none !important;
+    border-radius: 50% !important;
+    color: #ebd29e !important;
+    background: linear-gradient(145deg, rgba(77, 103, 169, 0.4), rgba(7, 18, 52, 0.78)) !important;
+    box-shadow: inset 0 0 0 2px rgba(5, 15, 45, 0.7) !important;
+    filter: none !important;
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) button[class*='newSession'] svg {
+    color: #f4dfa8 !important;
+    stroke-width: 1.9;
+    filter: drop-shadow(0 1px 2px rgba(1, 7, 24, 0.5));
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) [class*='newSessionLabel'],
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) [class*='panelTitle'] {
+    display: none !important;
+  }
+
+  /* Same compact treatment for the settings trigger. */
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    [class*='settingsArea'] button[aria-haspopup='dialog'] {
+    box-sizing: border-box !important;
+    width: 36px !important;
+    min-width: 36px !important;
+    max-width: 36px !important;
+    height: 36px !important;
+    min-height: 36px !important;
+    max-height: 36px !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: 1px solid rgba(225, 191, 124, 0.76) !important;
+    border-image: none !important;
+    border-radius: 50% !important;
+    justify-content: center !important;
+    align-items: center !important;
+    gap: 0 !important;
+    color: #dfbf7c !important;
+    background: linear-gradient(145deg, rgba(77, 103, 169, 0.48), rgba(7, 18, 52, 0.82)) !important;
+    box-shadow:
+      inset 0 0 0 2px rgba(5, 15, 45, 0.76),
+      0 3px 9px rgba(1, 7, 24, 0.24) !important;
+    filter: none !important;
+    overflow: visible !important;
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    [class*='settingsArea'] button[aria-haspopup='dialog'] [class*='triggerLabel'] {
+    display: none !important;
+  }
+
+  /* Rows that only make sense in the tall rail. */
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    :is(
+      [class*='regionArea'],
+      [class*='searchExpanded'],
+      [class*='sectionHeader'],
+      [data-skin-chrome='sidebar-mascot'],
+      [data-skin-chrome='sidebar-corners']
+    ) {
+    display: none !important;
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    :is([class*='footArea'], [class*='settingsArea'], [class*='footerActions']) {
+    flex-direction: row !important;
+    align-items: center !important;
+    margin: 0 0 0 auto !important;
+    padding: 0 !important;
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) [data-maid-sidebar-footer] {
+    flex-direction: row !important;
+    min-height: 0 !important;
+    padding: 0 !important;
+    background: none !important;
+    box-shadow: none !important;
+  }
+
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol']) [data-maid-sidebar-footer]::before {
+    display: none !important;
+  }
+
+  /* -- shared: expanded column floats over the conversation ---------------- */
+  html:not([data-maid-nav-mode='rail']) body[data-dsh-maid-atelier]
+    div:not([data-sidebar-collapsed]):has(> :is([data-pane='sidebar'], [class*='sidebarCol']))
+    :is([data-pane='sidebar'], [class*='sidebarCol']) {
+    position: fixed !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    width: min(300px, 84vw) !important;
+    height: 100dvh !important;
+    max-height: 100dvh !important;
+    z-index: 60 !important;
+    border-right: 0.5px solid var(--dsw-alias-border-l3) !important;
+    box-shadow: 24px 0 64px rgba(8, 17, 48, 0.35) !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain !important;
+  }
+
+  html:not([data-maid-nav-mode='rail']) body[data-dsh-maid-atelier]
+    div:has(> :is([data-pane='sidebar'], [class*='sidebarCol'])) > [class*='handle'] {
+    display: none !important;
+  }
+
+  html:not([data-maid-nav-mode='rail']) body[data-dsh-maid-atelier]
+    :is([data-pane='sidebar'], [class*='sidebarCol']):has([class*='regionArea']:not([style*='display: none'])) {
+    overscroll-behavior: contain !important;
+  }
+}
+
+/* Very narrow top bars keep the mark only. */
+@media (max-width: 420px) and (orientation: portrait) {
+  html[data-maid-nav-mode='topbar'] body[data-dsh-maid-atelier]
+    div[data-sidebar-collapsed]
+    :is([data-pane='sidebar'], [class*='sidebarCol'])
+    :is(
+      [class*='brandName'],
+      [class*='fallbackBrandName'],
+      [class*='localBuildBrand'],
+      [class*='buildVersion']
+    ) {
+    display: none !important;
+  }
+}
+
 /* Workspace groups receive skin-owned semantic hooks from the client entry.
    This keeps the ornamental tree independent from generated CSS-module names
    while leaving the official rows and their interactions intact. */

--- a/maid-atelier/tests/customization.spec.ts
+++ b/maid-atelier/tests/customization.spec.ts
@@ -11,7 +11,7 @@ afterEach(() => {
   vi.restoreAllMocks()
   document.body.innerHTML = ''
   for (const attribute of [...document.documentElement.attributes]) {
-    if (attribute.name.startsWith('data-dsh-whale-') || attribute.name.startsWith('data-maid-composer-')) {
+    if (attribute.name.startsWith('data-dsh-whale-') || attribute.name.startsWith('data-maid-composer-') || attribute.name.startsWith('data-maid-nav-')) {
       document.documentElement.removeAttribute(attribute.name)
     }
   }
@@ -24,9 +24,9 @@ describe('maid customization declaration', () => {
     window.addEventListener(SKIN_CUSTOMIZATION_REGISTER_EVENT, receive)
     const dispose = installMaidCustomization()
     const definition = registration!.definition
-    expect(definition.settings.map(setting => setting.key)).toEqual(['artwork', 'sfwMode', 'font', 'modelExit', 'mobileModelExit', 'composerMode'])
+    expect(definition.settings.map(setting => setting.key)).toEqual(['artwork', 'sfwMode', 'font', 'modelExit', 'mobileModelExit', 'mobileNav', 'composerMode'])
     const state = {
-      values: normalizeSkinValues(definition, { artwork: true, sfwMode: { enabled: true, outside: 'visible', ranges: [] }, font: 'serif', modelExit: false, composerMode: 'scroll' }),
+      values: normalizeSkinValues(definition, { artwork: true, sfwMode: { enabled: true, outside: 'visible', ranges: [] }, font: 'serif', modelExit: false, mobileNav: 'topbar', composerMode: 'scroll' }),
       visibility: { sfwMode: false },
     }
     document.body.innerHTML = '<div data-composer-card><button aria-haspopup="menu" title="DeepSeek-V4-Flash-Vision-Exp">DeepSeek-V4-Flash-Vision-Ex</button></div>'
@@ -35,6 +35,7 @@ describe('maid customization declaration', () => {
     expect(document.documentElement.getAttribute('data-dsh-whale-maid-art')).toBe('hidden')
     expect(document.documentElement.getAttribute('data-dsh-whale-maid-font')).toBe('serif')
     expect(document.documentElement.getAttribute('data-maid-composer-mode')).toBe('scroll')
+    expect(document.documentElement.getAttribute('data-maid-nav-mode')).toBe('topbar')
     expect(document.documentElement.getAttribute('data-dsh-whale-maid-model-exit')).toBe('disabled')
     width.mockReturnValue(420)
     window.dispatchEvent(new Event('resize'))
@@ -55,6 +56,7 @@ describe('maid customization declaration', () => {
     expect(document.documentElement.hasAttribute('data-dsh-whale-model')).toBe(false)
     expect(document.documentElement.hasAttribute('data-dsh-whale-maid-art')).toBe(false)
     expect(document.documentElement.hasAttribute('data-maid-composer-mode')).toBe(false)
+    expect(document.documentElement.hasAttribute('data-maid-nav-mode')).toBe(false)
     window.removeEventListener(SKIN_CUSTOMIZATION_REGISTER_EVENT, receive)
   })
 
@@ -69,6 +71,32 @@ describe('maid customization declaration', () => {
     expect(composerMode && composerMode.type === 'select' ? composerMode.options.map(option => option.label) : []).toEqual(['始终显示', '空态胶囊（点击展开）', '上滚隐去 · 下滚渐现'])
     expect(composerMode && composerMode.type === 'select' ? composerMode.options.map(option => option.labelEn) : []).toEqual(['Always visible', 'Idle capsule (click to expand)', 'Hide on scroll up · show on scroll down'])
     dispose()
+    window.removeEventListener(SKIN_CUSTOMIZATION_REGISTER_EVENT, receive)
+  })
+
+  it('exposes the phone navigation layouts and defaults to the corner mark', () => {
+    let registration: SkinCustomizationRegistration | undefined
+    const receive = (event: Event) => { registration = (event as CustomEvent<SkinCustomizationRegistration>).detail }
+    window.addEventListener(SKIN_CUSTOMIZATION_REGISTER_EVENT, receive)
+    const dispose = installMaidCustomization()
+    const definition = registration!.definition
+    const mobileNav = definition.settings.find(setting => setting.key === 'mobileNav')
+    expect(mobileNav?.type).toBe('select')
+    expect(mobileNav?.defaultValue).toBe('corner')
+    expect(mobileNav && mobileNav.type === 'select' ? mobileNav.options.map(option => option.value) : []).toEqual(['corner', 'topbar', 'rail'])
+
+    // A missing value and an unknown value both mean the skin default, so a phone
+    // still gets the corner mark before the manager has pushed anything.
+    const blank = normalizeSkinValues(definition, {})
+    definition.apply({ values: blank, visibility: { sfwMode: true } })
+    expect(document.documentElement.getAttribute('data-maid-nav-mode')).toBe('corner')
+    definition.apply({ values: { ...blank, mobileNav: 'nonsense' }, visibility: { sfwMode: true } })
+    expect(document.documentElement.getAttribute('data-maid-nav-mode')).toBe('corner')
+    definition.apply({ values: { ...blank, mobileNav: 'rail' }, visibility: { sfwMode: true } })
+    expect(document.documentElement.getAttribute('data-maid-nav-mode')).toBe('rail')
+
+    dispose()
+    expect(document.documentElement.hasAttribute('data-maid-nav-mode')).toBe(false)
     window.removeEventListener(SKIN_CUSTOMIZATION_REGISTER_EVENT, receive)
   })
 


### PR DESCRIPTION
# feat(mobile): make the phone navigation layout a setting with three modes

Branch: **`feat/phone-navigation-modes`** (1 commit on top of `origin/main` @ `daa6c69`) · +485/−3 · 3 files
Base: `Small-tailqwq/dsh-deep-whale` → `maid-atelier/`

This is the answer to **open point 2 of #122** ("the dock is the only phone-portrait mode; there is no way back to the rail or the top bar"). Instead of choosing a layout unilaterally, all three become one value of the skin's existing customization, so nobody loses the layout they were using.

| `mobileNav` — "Phone navigation layout" in the skin manager | phone portrait (≤700px) |
|---|---|
| **`corner`** *(default)* | the toggle becomes a 48px brand button in the top-left corner; the column is out of flow, the conversation owns the full width |
| **`topbar`** | the same chrome spread as a 48px bar across the top |
| **`rail`** | no rule matches — the host's own 56px column, exactly as it is today |

The value travels on `data-maid-nav-mode` on the document element, where the skin's projector already writes. A missing or unknown value means `corner`, so a fresh profile or an install without the skin manager still gets a working phone layout.

## What it changes

| file | what |
|---|---|
| `src/client/customization.ts` | +19: the `mobileNav` declaration (`select`, 3 options, `corner` default) and its projection onto `data-maid-nav-mode` |
| `src/client/maid-atelier.module.css` | +435: the two reflowed layouts under `html:not([data-maid-nav-mode='rail'])` |
| `tests/customization.spec.ts` | +34/−3: the projection assertions |

**No new JavaScript module** — this is a stylesheet plus the customization value the skin already had. Nothing in #124 is contained here, and nothing here depends on #122's dock: if the dock proposal is dropped, this PR is unaffected.

## Implementation notes

- In both reflowed modes the column leaves the layout — collapsed it *is* the corner button or the bar, expanded it is the host's overlay drawer. The frame therefore never keeps the grid track the column vacated: the conversation column goes **334 → 390px** and keeps it in both states.
- Hooks are the host's own (`data-sidebar-collapsed`, `sidebarCol`, `logoRow` / `toggle`, `panelList`, `newSession`, `settingsArea`), with a `@supports not (selector(:has(*)))` arm, so no hashed class name is matched and a later host build cannot silently reintroduce a row into the corner button.
- The host header keeps its own row, order and behaviour; it only starts after the corner button (`padding-left: 64px` clears the 48px button at `left: 10px`, 6px of clearance to the breadcrumb).
- `rail` matches no rule at all — it is the host's layout, untouched, so it stays correct however the host evolves.
- `z-index: 40` stays inside the host's layer contract (menu 100 / modal 1000). Landscape and desktop are untouched.

## Verification

Measured in a running GUI at **390x844**, switching the value through the skin manager's own select:

| | `corner` (default) | `topbar` | `rail` |
|---|---|---|---|
| toggle / bar | 48x48 at (10, 6) | bar 390x49 at (0, 0), toggle 36x36 at (8, 6) | host column 56x844, toggle 36x36 at (10, 27) |
| conversation column | **390x844** | **390x795** (starts at y=49) | 334x844 (starts at x=56) |
| header `padding-left` | 64px | 20px | 20px |
| breadcrumb clearance | **6px** | n/a (bar is the header) | 30px |
| expanded drawer | 301x844 overlay | 301x844 overlay | 280x844 |
| horizontal spill (`scrollWidth` vs viewport) | 390 = 390 | 390 = 390 | 390 = 390 |
| console errors | 0 | 0 | 0 |

The toggle opens and closes the drawer in every mode. The geometry above was measured on a build that also carried the defect fixes of #124 (the two are independent — this branch contains none of that code, and #124 contains none of this).

On this branch: `npx vitest run` → **8 files, 162 tests pass**, and `npx tsdown` builds the client bundle.

## Build output

`lib/` is not included, same as #119/#120/#122/#124: `npm run build` cannot run outside the scaffolding checkout (`src/client/customization.ts` resolves `../../../skin-manager/src/protocol.ts`, and the build script calls `../scripts/write-skin-build.mjs`). Regenerate the bundles where the full tree is available; `skin.build.json` follows from `npm run build`.
